### PR TITLE
Add global content selection to send flow

### DIFF
--- a/desktop/src/App.css
+++ b/desktop/src/App.css
@@ -47,6 +47,12 @@ h2 { margin: 0; color: #27312c; font-size: 16px; line-height: 1.3; letter-spacin
 .page { width: min(1080px, calc(100% - 60px)); margin: 0 auto; padding: 42px 0 64px; }
 .page-header { margin-bottom: 30px; }
 .page-header-with-action { display: flex; align-items: flex-start; justify-content: space-between; gap: 20px; }
+.global-select-toggle { display: flex; flex: 0 0 auto; align-items: center; gap: 9px; min-height: 40px; padding: 4px 0; color: #33423a; cursor: pointer; }
+.global-select-toggle input { width: 16px; height: 16px; margin: 0; accent-color: #247355; }
+.global-select-toggle span { display: grid; gap: 2px; }
+.global-select-toggle strong { font-size: 12px; }
+.global-select-toggle small { color: #748079; font-size: 10px; }
+.global-select-toggle:has(input:disabled) { color: #9aa49f; cursor: not-allowed; }
 .eyebrow, .section-kicker { margin-bottom: 7px; color: #68766f; font-size: 10px; font-weight: 800; letter-spacing: 0; }
 .page-description { margin-bottom: 0; color: #66736c; font-size: 13px; }
 .page-error { margin-top: 18px; }
@@ -260,6 +266,8 @@ h2 { margin: 0; color: #27312c; font-size: 16px; line-height: 1.3; letter-spacin
   .sidebar-meta { justify-content: center; padding-inline: 0; }
   .topbar { padding: 0 18px; }
   .page { width: min(100% - 28px, 680px); padding-top: 28px; }
+  .page-header-with-action { align-items: stretch; flex-direction: column; }
+  .global-select-toggle { align-self: flex-start; }
   .action-strip, .compact-choices, .result-grid, .verification-list { grid-template-columns: 1fr; }
   .compact-choices .choice-row:nth-last-child(2n), .result-grid > span { border-right: 0; }
   .form-row { grid-template-columns: 1fr; align-items: stretch; padding: 12px 0; }

--- a/desktop/src/App.test.tsx
+++ b/desktop/src/App.test.tsx
@@ -350,6 +350,24 @@ describe("ReHome Desktop workflows", () => {
     expect(screen.getByRole("checkbox", { name: "选择项目 rehome-app" })).toBeChecked();
   });
 
+  it("selects and clears every migration item with the global select control", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await screen.findByText(inventory.codex_home);
+    await user.click(screen.getByRole("button", { name: "前往发送" }));
+
+    const selectAll = screen.getByRole("checkbox", { name: "全选迁移内容" });
+    await user.click(selectAll);
+
+    expect(selectAll).toBeChecked();
+    expect(screen.getByRole("button", { name: "创建 ReHome 包" })).toBeEnabled();
+
+    await user.click(selectAll);
+
+    expect(selectAll).not.toBeChecked();
+    expect(screen.getByRole("button", { name: "创建 ReHome 包" })).toBeDisabled();
+  });
+
   it("allows a conversation-only package without selecting project files", async () => {
     const user = userEvent.setup();
     render(<App />);

--- a/desktop/src/features/send/SendPage.tsx
+++ b/desktop/src/features/send/SendPage.tsx
@@ -55,6 +55,24 @@ export default function SendPage({ headingRef, inventory }: SendPageProps) {
 
   const hasContent =
     projects.size + conversations.size + skills.size + plugins.size + images.size > 0;
+  const hasSelectableContent = Boolean(
+    inventory &&
+      inventory.projects.length +
+        inventory.conversations.length +
+        inventory.skills.length +
+        inventory.plugins.length +
+        inventory.generated_images.length >
+        0,
+  );
+  const allContentSelected = Boolean(
+    inventory &&
+      hasSelectableContent &&
+      inventory.projects.every((project) => projects.has(project.project_id)) &&
+      inventory.conversations.every((conversation) => conversations.has(conversation.task_id)) &&
+      inventory.skills.every((skill) => skills.has(skill.content_id)) &&
+      inventory.plugins.every((plugin) => plugins.has(plugin.content_id)) &&
+      inventory.generated_images.every((image) => images.has(image.content_id)),
+  );
   const canCreate = Boolean(inventory && hasContent && !busy);
 
   function toggle(setter: (value: Set<string>) => void, current: Set<string>, value: string) {
@@ -88,6 +106,25 @@ export default function SendPage({ headingRef, inventory }: SendPageProps) {
     setConversations(nextConversations);
   }
 
+  function toggleAllContent() {
+    if (!inventory) return;
+
+    if (allContentSelected) {
+      setProjects(new Set());
+      setConversations(new Set());
+      setSkills(new Set());
+      setPlugins(new Set());
+      setImages(new Set());
+      return;
+    }
+
+    setProjects(new Set(inventory.projects.map((project) => project.project_id)));
+    setConversations(new Set(inventory.conversations.map((conversation) => conversation.task_id)));
+    setSkills(new Set(inventory.skills.map((skill) => skill.content_id)));
+    setPlugins(new Set(inventory.plugins.map((plugin) => plugin.content_id)));
+    setImages(new Set(inventory.generated_images.map((image) => image.content_id)));
+  }
+
   async function handleCreate() {
     if (!inventory || !canCreate) return;
     setError(null);
@@ -110,10 +147,25 @@ export default function SendPage({ headingRef, inventory }: SendPageProps) {
 
   return (
     <div className="page">
-      <header className="page-header">
-        <p className="eyebrow">SEND</p>
-        <h1 ref={headingRef} tabIndex={-1}>发送交接</h1>
-        <p className="page-description">项目文件、对话和其他 Codex 内容都可以分开选择。</p>
+      <header className="page-header page-header-with-action">
+        <div>
+          <p className="eyebrow">SEND</p>
+          <h1 ref={headingRef} tabIndex={-1}>发送交接</h1>
+          <p className="page-description">项目文件、对话和其他 Codex 内容都可以分开选择。</p>
+        </div>
+        <label className="global-select-toggle">
+          <input
+            type="checkbox"
+            checked={allContentSelected}
+            onChange={toggleAllContent}
+            disabled={!hasSelectableContent}
+            aria-label="全选迁移内容"
+          />
+          <span>
+            <strong>全选迁移内容</strong>
+            <small>项目、对话和 Codex 内容</small>
+          </span>
+        </label>
       </header>
 
       <section className="workflow-section" aria-labelledby="send-projects-title">


### PR DESCRIPTION
## Summary
- add a right-aligned global select control on the send page
- include projects, conversations, skills, plugins, and generated images
- keep granular per-item selection available

## Verification
- npm test -- --run
- npm run build