### PR TITLE
Handle project links and repair missing session indexes

### DIFF
--- a/desktop/src-tauri/src/core/backup.rs
+++ b/desktop/src-tauri/src/core/backup.rs
@@ -65,6 +65,8 @@ pub(crate) struct BackupOperation {
     pub backup_path: Option<PathBuf>,
     pub original_hash: Option<String>,
     #[serde(default)]
+    pub original_target_hash: Option<String>,
+    #[serde(default)]
     pub applied_hash: Option<String>,
     #[serde(default)]
     pub applied_state: Option<AppliedState>,
@@ -166,6 +168,29 @@ pub(crate) fn prepare_transaction(
             )?
         };
         operations.push(operation);
+    }
+
+    // An existing WAL or journal is folded into the self-contained database
+    // backup. If a later operation fails before SQLite is written, rollback
+    // must still restore that snapshot before removing the original sidecar.
+    let has_sqlite_sidecar = operations.iter().any(|operation| {
+        operation
+            .package_source
+            .starts_with("codex/metadata/sqlite-sidecar")
+            && operation.applied_state.is_some()
+    });
+    if has_sqlite_sidecar {
+        if let Some(index) = operations
+            .iter()
+            .position(|operation| operation.package_source == "codex/metadata/threads.json")
+        {
+            let applied_state = inspect_applied_state(&operations[index])?;
+            operations[index].applied_hash = match &applied_state {
+                AppliedState::File { hash, .. } => Some(hash.clone()),
+                AppliedState::Absent => None,
+            };
+            operations[index].applied_state = Some(applied_state);
+        }
     }
 
     let locks = operations
@@ -679,7 +704,8 @@ fn backup_target(
                 target,
                 backup_kind: BackupKind::File,
                 backup_path: Some(relative),
-                original_hash: Some(before_hash),
+                original_hash: Some(before_hash.clone()),
+                original_target_hash: Some(before_hash),
                 applied_hash: None,
                 applied_state: None,
                 applied_database_hash: None,
@@ -702,6 +728,7 @@ fn backup_target(
                 backup_kind: BackupKind::Absent,
                 backup_path: None,
                 original_hash: None,
+                original_target_hash: None,
                 applied_hash: None,
                 applied_state: None,
                 applied_database_hash: None,
@@ -797,6 +824,7 @@ fn backup_sqlite_database(
         backup_kind: BackupKind::File,
         backup_path: Some(relative),
         original_hash: Some(original_hash),
+        original_target_hash: Some(before_hash),
         applied_hash: None,
         applied_state: None,
         applied_database_hash: None,
@@ -844,6 +872,7 @@ fn backup_sqlite_sidecar(
         backup_kind: BackupKind::Absent,
         backup_path: None,
         original_hash: original_hash.clone(),
+        original_target_hash: original_hash.clone(),
         applied_hash: original_hash.clone(),
         // Existing WAL/SHM content is already folded into the coherent SQLite
         // snapshot. Record its identity so rollback can quarantine that exact
@@ -1121,10 +1150,15 @@ fn verify_original_operation_state(operation: &BackupOperation) -> Result<(), Re
             "rollback conflict: target is present after its recorded restoration",
         );
     }
-    let expected = operation
-        .original_hash
-        .as_deref()
-        .ok_or_else(|| rollback_failed("file backup has no original hash"))?;
+    let expected = if operation.applied_state.is_none() {
+        operation
+            .original_target_hash
+            .as_deref()
+            .or(operation.original_hash.as_deref())
+    } else {
+        operation.original_hash.as_deref()
+    }
+    .ok_or_else(|| rollback_failed("file backup has no original hash"))?;
     let (actual, _) = inspect_current_file(operation)?;
     if actual.eq_ignore_ascii_case(expected) {
         Ok(())

--- a/desktop/src-tauri/src/core/bridge.rs
+++ b/desktop/src-tauri/src/core/bridge.rs
@@ -388,11 +388,18 @@ pub fn merge_session_index(
 
     let mut merged_rows = BTreeMap::new();
     for (id, session) in &planned {
-        let incoming = imported.get(id).ok_or_else(|| {
-            package_invalid(format!(
-                "session index is missing planned conversation {id}"
-            ))
-        })?;
+        let source_id = session.source_task_id.to_string();
+        let incoming = imported
+            .get(id)
+            .or_else(|| imported.get(&source_id))
+            .cloned()
+            .unwrap_or_else(|| {
+                serde_json::json!({
+                    "id": source_id,
+                    "thread_name": session.title,
+                    "title": session.title,
+                })
+            });
         let mut row = target_bases
             .remove(id)
             .unwrap_or_else(|| Value::Object(Map::new()));

--- a/desktop/src-tauri/src/core/package.rs
+++ b/desktop/src-tauri/src/core/package.rs
@@ -57,6 +57,7 @@ const EXCLUSION_RULES: &[&str] = &[
     "environment and private key files",
     "version-control metadata",
     "dependency, cache, build, and runtime data",
+    "symbolic links and filesystem redirects",
 ];
 
 pub fn create_package(request: CreatePackageRequest) -> Result<CreatePackageReport, RehomeError> {
@@ -597,9 +598,12 @@ fn stage_projects(
                 continue;
             }
             if entry.file_type().is_symlink() {
-                return Err(package_invalid(
-                    "symbolic links are not allowed in selected projects",
-                ));
+                let length = fs::symlink_metadata(entry.path())
+                    .map(|metadata| metadata.len())
+                    .unwrap_or(0);
+                excluded_files += 1;
+                excluded_bytes += length;
+                continue;
             }
             if !entry.file_type().is_file() {
                 continue;

--- a/desktop/src-tauri/src/core/package.rs
+++ b/desktop/src-tauri/src/core/package.rs
@@ -129,12 +129,13 @@ fn create_package_with_overwrite(
         &mut counts,
     )?;
 
-    if !index_metadata.bytes.is_empty() {
+    let complete_index = complete_session_index(&index_metadata, &conversations)?;
+    if !complete_index.is_empty() {
         stage_generated(
             staging.path(),
             &mut payloads,
             "codex/session_index.jsonl",
-            &index_metadata.bytes,
+            &complete_index,
         )?;
     }
 
@@ -547,7 +548,6 @@ impl PayloadCollection {
 
 #[derive(Default)]
 struct SessionIndexMetadata {
-    bytes: Vec<u8>,
     by_id: BTreeMap<Uuid, Value>,
 }
 
@@ -557,6 +557,33 @@ struct ConversationSelection<'a> {
     selected_ids: &'a [Uuid],
     index: &'a SessionIndexMetadata,
     projects: &'a [ProjectEntry],
+}
+
+fn complete_session_index(
+    index: &SessionIndexMetadata,
+    conversations: &[ConversationEntry],
+) -> Result<Vec<u8>, RehomeError> {
+    let mut bytes = Vec::new();
+    for conversation in conversations {
+        let value = index
+            .by_id
+            .get(&conversation.task_id)
+            .cloned()
+            .unwrap_or_else(|| {
+                serde_json::json!({
+                    "id": conversation.task_id,
+                    "thread_name": conversation.title,
+                    "title": conversation.title,
+                    "updated_at": conversation.updated_at,
+                    "project_id": conversation.project_id,
+                })
+            });
+        serde_json::to_writer(&mut bytes, &value)
+            .map_err(|error| package_invalid(format!("could not encode session index: {error}")))?;
+        bytes.push(b'\n');
+        ensure_control_size("codex/session_index.jsonl", bytes.len() as u64)?;
+    }
+    Ok(bytes)
 }
 
 fn stage_projects(
@@ -762,13 +789,6 @@ fn read_selected_session_index(
         return Err(package_invalid(
             "source file changed in size or modification time while being read",
         ));
-    }
-    for value in result.by_id.values() {
-        let encoded = serde_json::to_vec(value)
-            .map_err(|error| package_invalid(format!("could not encode session index: {error}")))?;
-        result.bytes.extend_from_slice(&encoded);
-        result.bytes.push(b'\n');
-        ensure_control_size("codex/session_index.jsonl", result.bytes.len() as u64)?;
     }
     Ok(result)
 }

--- a/desktop/src-tauri/tests/bridge_test.rs
+++ b/desktop/src-tauri/tests/bridge_test.rs
@@ -158,6 +158,34 @@ fn session_index_merge_preserves_target_rows_and_repairs_planned_metadata(
 }
 
 #[test]
+fn session_index_merge_repairs_an_old_package_with_a_missing_planned_row(
+) -> Result<(), Box<dyn Error>> {
+    let unrelated = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    let package = jsonl(&[serde_json::json!({
+        "id": unrelated,
+        "title": "Unrelated",
+    })]);
+
+    let merged = merge_session_index(
+        b"",
+        package.as_bytes(),
+        &[planned_session()],
+        &rewrites(INDEX_SOURCE),
+    )?;
+    let rows = merged
+        .split(|byte| *byte == b'\n')
+        .filter(|line| !line.is_empty())
+        .map(serde_json::from_slice::<Value>)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["id"], TARGET_ID);
+    assert_eq!(rows[0]["title"], planned_session().title);
+    assert_eq!(rows[0]["rollout_path"], MAC_SESSION);
+    Ok(())
+}
+
+#[test]
 fn session_index_merge_preserves_newer_target_metadata_and_unrelated_duplicate_rows_exactly(
 ) -> Result<(), Box<dyn Error>> {
     let unrelated = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";

--- a/desktop/src-tauri/tests/package_test.rs
+++ b/desktop/src-tauri/tests/package_test.rs
@@ -767,6 +767,27 @@ fn sensitive_staging_never_appears_in_project_or_output_directories() -> Result<
 }
 
 #[test]
+fn package_synthesizes_a_missing_selected_session_index_row() -> Result<(), Box<dyn Error>> {
+    let fixture = synthetic_codex_fixture()?;
+    fs::remove_file(&fixture.session_index_path)?;
+    let directory = tempfile::tempdir()?;
+    let package = directory.path().join("synthesized-index.rehome");
+
+    create_package(package_request(&fixture, package.clone()))?;
+
+    let index = String::from_utf8(read_zip_entry(&package, "codex/session_index.jsonl")?)?;
+    let rows = index
+        .lines()
+        .map(serde_json::from_str)
+        .collect::<Result<Vec<Value>, _>>()?;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["id"], THREAD_ID);
+    assert_eq!(rows[0]["thread_name"], "Imported conversation");
+    assert_eq!(rows[0]["title"], "Imported conversation");
+    Ok(())
+}
+
+#[test]
 fn symbolic_links_in_selected_projects_are_safely_excluded() -> Result<(), Box<dyn Error>> {
     let fixture = synthetic_codex_fixture()?;
     let outside = fixture.root.join("outside-secret.txt");

--- a/desktop/src-tauri/tests/package_test.rs
+++ b/desktop/src-tauri/tests/package_test.rs
@@ -767,6 +767,35 @@ fn sensitive_staging_never_appears_in_project_or_output_directories() -> Result<
 }
 
 #[test]
+fn symbolic_links_in_selected_projects_are_safely_excluded() -> Result<(), Box<dyn Error>> {
+    let fixture = synthetic_codex_fixture()?;
+    let outside = fixture.root.join("outside-secret.txt");
+    fs::write(&outside, b"must not enter the package\n")?;
+    let linked = fixture.project_path.join("linked-secret.txt");
+    if let Err(error) = create_file_symlink(&outside, &linked) {
+        if windows_symlink_privilege_is_unavailable(&error) {
+            eprintln!("skipping project symlink test: Windows symlink privilege unavailable");
+            return Ok(());
+        }
+        return Err(error.into());
+    }
+    let directory = tempfile::tempdir()?;
+    let package = directory.path().join("symlink-safe.rehome");
+
+    create_package(package_request(&fixture, package.clone()))?;
+
+    let preview = inspect_package(&package)?;
+    assert_eq!(preview.manifest.counts.projects, 1);
+    assert_eq!(preview.manifest.counts.project_files, 1);
+    assert_eq!(preview.manifest.exclusions.excluded_files, 4);
+    assert!(!preview
+        .entries
+        .iter()
+        .any(|entry| entry.ends_with("/linked-secret.txt")));
+    Ok(())
+}
+
+#[test]
 fn aborts_if_a_source_changes_while_it_is_copied() -> Result<(), Box<dyn Error>> {
     let fixture = synthetic_codex_fixture()?;
     let large_source = fixture.project_path.join("large.bin");
@@ -839,6 +868,26 @@ fn directory_entry_names(root: &Path) -> Result<Vec<String>, Box<dyn Error>> {
         .collect::<Result<Vec<_>, io::Error>>()?;
     names.sort();
     Ok(names)
+}
+
+#[cfg(unix)]
+fn create_file_symlink(target: &Path, link: &Path) -> io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(windows)]
+fn create_file_symlink(target: &Path, link: &Path) -> io::Result<()> {
+    std::os::windows::fs::symlink_file(target, link)
+}
+
+#[cfg(not(windows))]
+fn windows_symlink_privilege_is_unavailable(_error: &io::Error) -> bool {
+    false
+}
+
+#[cfg(windows)]
+fn windows_symlink_privilege_is_unavailable(error: &io::Error) -> bool {
+    error.raw_os_error() == Some(1314)
 }
 
 fn read_zip_entry(path: &Path, name: &str) -> Result<Vec<u8>, Box<dyn Error>> {

--- a/desktop/src-tauri/tests/restore_test.rs
+++ b/desktop/src-tauri/tests/restore_test.rs
@@ -305,6 +305,56 @@ fn sqlite_wal_verification_failure_refreshes_sidecars_before_rollback() -> Resul
 }
 
 #[test]
+fn index_failure_before_sqlite_write_restores_a_wal_snapshot_without_false_conflict(
+) -> Result<(), Box<dyn Error>> {
+    let mut harness = RestoreHarness::new(DatabaseSchema::Compatible)?;
+    let database = harness.plan.target_codex_home.join("state_5.sqlite");
+    let generator = harness._fixture.root.join("rollback-generator.sqlite");
+    fs::copy(&database, &generator)?;
+    let keeper = Connection::open(&generator)?;
+    keeper.pragma_update(None, "journal_mode", "WAL")?;
+    keeper.pragma_update(None, "wal_autocheckpoint", 0)?;
+    keeper.execute_batch(
+        "CREATE TABLE rollback_marker(value TEXT NOT NULL);\
+         INSERT INTO rollback_marker VALUES ('from-wal');",
+    )?;
+    fs::copy(&generator, &database)?;
+    for suffix in ["-wal", "-shm"] {
+        let source = sqlite_sidecar(&generator, suffix);
+        if source.exists() {
+            fs::copy(source, sqlite_sidecar(&database, suffix))?;
+        }
+    }
+    drop(keeper);
+    assert!(sqlite_sidecar(&database, "-wal").exists());
+    fs::write(
+        harness.plan.target_codex_home.join("session_index.jsonl"),
+        b"{}\n",
+    )?;
+    let preview = inspect_package(&harness.plan.package_path)?;
+    let target = TargetInventory {
+        codex_home: harness.plan.target_codex_home.clone(),
+        target_os: current_source_os(),
+        target_arch: "x86_64".into(),
+        counts: ContentCounts::default(),
+        projects: vec![],
+        conversations: vec![],
+    };
+    harness.plan = build_restore_plan(&preview, &target, &harness.plan.projects_root)?;
+
+    let error = apply_restore(harness.plan.clone(), harness.options()).unwrap_err();
+
+    assert_eq!(error.code, ErrorCode::RestoreFailed, "{error:?}");
+    assert!(!error.message.contains("automatic rollback failed"));
+    assert_eq!(harness.single_journal_status()?, RecoveryStatus::RolledBack);
+    let restored = Connection::open(database)?;
+    let marker: String =
+        restored.query_row("SELECT value FROM rollback_marker", [], |row| row.get(0))?;
+    assert_eq!(marker, "from-wal");
+    Ok(())
+}
+
+#[test]
 fn backup_root_must_not_overlap_projects_root() -> Result<(), Box<dyn Error>> {
     let harness = RestoreHarness::new(DatabaseSchema::Compatible)?;
     let error = apply_restore(


### PR DESCRIPTION
﻿## What changed

- Skip symbolic links and filesystem redirects inside selected projects instead of aborting the whole export.
- Synthesize missing session-index rows during package creation.
- Repair incomplete session indexes from older `.rehome` packages during restore.
- Track both the live SQLite file hash and the coherent backup snapshot hash.
- Restore WAL-backed SQLite snapshots safely when an earlier bridge step fails.

## Why

Users reported two failures:

1. Export stopped with `symbolic links are not allowed in selected projects`.
2. Restore stopped because `session index is missing planned conversation`, followed by a false SQLite rollback hash conflict.

The first was caused by treating a safely skippable project link as a fatal package error. The second combined an incomplete source index with two physically different but valid SQLite representations: the live database plus WAL and the self-contained backup snapshot.

## Impact

Exports now continue without following links or copying linked external content. Restores can repair missing conversation index entries while preserving the authenticated session JSONL, and failed restores no longer report a false rollback conflict for untouched or WAL-backed SQLite state.

## Validation

- `cargo test` (188 passed, 1 local acceptance test ignored by design)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `npm test -- --run` (24/24 passed)
- `npm run build`
- `cargo build --release`
