### PR TITLE
Release ReHome Desktop v0.1.3

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rehome-desktop",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rehome-desktop",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0",
         "lucide-react": "^0.468.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rehome-desktop",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2793,7 +2793,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rehome-desktop"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rehome-desktop"
-version = "0.1.2"
+version = "0.1.3"
 description = "ReHome Desktop migration utility"
 authors = ["ReHome contributors"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ReHome Desktop",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "identifier": "com.calebycj.rehome",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
﻿## Release

Prepare ReHome Desktop v0.1.3 after merging the project-link and session-index recovery fixes.

## Included fixes

- Safely skip symbolic links and filesystem redirects during project export.
- Synthesize missing session-index rows when creating packages.
- Repair incomplete session indexes from older packages during restore.
- Prevent false SQLite/WAL rollback hash conflicts.

## Version alignment

Updated the npm package, npm lockfile, Cargo package, Cargo lockfile, and Tauri configuration to 0.1.3.

## Validation

- `npm test -- --run` (24/24 passed)
- `npm run build`
- `cargo check --locked`
- Full cross-platform test and installer workflow passed for the preceding fix PR.
