### PR TITLE
Fix updater release asset URLs

### DIFF
--- a/scripts/generate-updater-json.mjs
+++ b/scripts/generate-updater-json.mjs
@@ -18,7 +18,7 @@ const macBundle = findOne(files, (name) => name.endsWith(".app.tar.gz"), "macOS 
 const windowsSignature = readSignature(assetsDirectory, `${windowsBundle}.sig`);
 const macSignature = readSignature(assetsDirectory, `${macBundle}.sig`);
 const releaseBase = `https://github.com/${repository}/releases/download/${encodeURIComponent(tag)}`;
-const assetUrl = (name) => `${releaseBase}/${encodeURIComponent(basename(name))}`;
+const assetUrl = (name) => `${releaseBase}/${encodeURIComponent(githubAssetName(name))}`;
 
 const manifest = {
   version,
@@ -54,4 +54,9 @@ function readSignature(directory, name) {
   const signature = readFileSync(join(directory, name), "utf8").trim();
   if (!signature) throw new Error(`Empty updater signature: ${name}`);
   return signature;
+}
+
+// GitHub normalizes spaces in uploaded release asset names to periods.
+function githubAssetName(name) {
+  return basename(name).replaceAll(" ", ".");
 }

--- a/scripts/generate-updater-json.test.mjs
+++ b/scripts/generate-updater-json.test.mjs
@@ -31,7 +31,9 @@ test("generates one manifest for Windows and both Universal macOS architectures"
       manifest.platforms["darwin-aarch64"],
       manifest.platforms["darwin-x86_64"],
     );
-    assert.match(manifest.platforms["windows-x86_64"].url, /ReHome%20Desktop/);
+    assert.match(manifest.platforms["windows-x86_64"].url, /ReHome\.Desktop/);
+    assert.doesNotMatch(manifest.platforms["windows-x86_64"].url, /%20/);
+    assert.match(manifest.platforms["darwin-x86_64"].url, /ReHome\.Desktop\.app\.tar\.gz$/);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- match GitHub's release asset name normalization when generating updater URLs
- add regression coverage for filenames containing spaces

## Verification
- updater manifest test passes
- generated normalized Windows and macOS asset URLs return HTTP 200
- existing space-based URLs return 404, reproducing the release issue