### PR TITLE
Fix package creation with nested plugin manifests

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -120,6 +120,9 @@ jobs:
         run: |
           mkdir -p release-assets
           cp desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg release-assets/
+      - name: Stage signed macOS updater
+        if: startsWith(github.ref, 'refs/tags/desktop-v')
+        run: |
           shopt -s nullglob
           updater_bundles=(desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/*.app.tar.gz)
           updater_signatures=(desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/*.app.tar.gz.sig)

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rehome-desktop",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rehome-desktop",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-process": "^2.3.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rehome-desktop",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2886,7 +2886,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rehome-desktop"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rehome-desktop"
-version = "0.1.4"
+version = "0.1.5"
 description = "ReHome Desktop migration utility"
 authors = ["ReHome contributors"]
 edition = "2021"

--- a/desktop/src-tauri/src/core/discovery.rs
+++ b/desktop/src-tauri/src/core/discovery.rs
@@ -815,31 +815,53 @@ fn optional_tree_entries(
     kind: &str,
     expand_plugin_root: bool,
 ) -> Vec<OptionalContentEntry> {
-    let mut seen = HashSet::new();
-    let mut entries = markers
+    let mut bundles = markers
         .iter()
         .filter_map(|marker| {
             let marker_parent = marker.parent()?;
-            let bundle = if expand_plugin_root
-                && marker_parent.file_name().and_then(|name| name.to_str()) == Some(".codex-plugin")
-            {
+            let is_modern_plugin = expand_plugin_root
+                && marker_parent.file_name().and_then(|name| name.to_str())
+                    == Some(".codex-plugin");
+            let bundle = if is_modern_plugin {
                 marker_parent.parent()?
             } else if !expand_plugin_root {
                 outermost_skill_bundle(marker, root)?
             } else {
                 marker_parent
             };
+            Some((bundle.to_path_buf(), marker.clone(), is_modern_plugin))
+        })
+        .collect::<Vec<_>>();
+    bundles.sort_by(|left, right| {
+        left.0
+            .components()
+            .count()
+            .cmp(&right.0.components().count())
+            .then(left.0.cmp(&right.0))
+    });
+
+    let mut selected_bundles = Vec::new();
+    for candidate in bundles {
+        if selected_bundles
+            .iter()
+            .any(|(selected, _, _): &(PathBuf, PathBuf, bool)| candidate.0.starts_with(selected))
+        {
+            continue;
+        }
+        selected_bundles.push(candidate);
+    }
+
+    let mut entries = selected_bundles
+        .into_iter()
+        .filter_map(|(bundle, marker, is_modern_plugin)| {
             let relative = bundle.strip_prefix(root).ok()?;
             let relative_path = normalize_entry(relative).ok()?;
-            if !seen.insert(relative_path.clone()) {
-                return None;
-            }
             Some(OptionalContentEntry {
                 content_id: Uuid::new_v5(
                     &Uuid::NAMESPACE_URL,
                     format!("{kind}:{relative_path}").as_bytes(),
                 ),
-                name: if expand_plugin_root {
+                name: if is_modern_plugin {
                     bundle.parent().and_then(Path::file_name)
                 } else {
                     bundle.file_name()
@@ -848,12 +870,12 @@ fn optional_tree_entries(
                 .unwrap_or(kind)
                 .to_owned(),
                 source_path: if expand_plugin_root {
-                    marker.clone()
+                    marker
                 } else {
                     bundle.join("SKILL.md")
                 },
                 relative_path,
-                size_bytes: directory_size(bundle),
+                size_bytes: directory_size(&bundle),
                 thumbnail_data_url: None,
                 reveal_id: None,
             })

--- a/desktop/src-tauri/src/core/package.rs
+++ b/desktop/src-tauri/src/core/package.rs
@@ -496,8 +496,10 @@ struct PortablePathRegistry {
 impl PortablePathRegistry {
     fn insert(&mut self, path: &str, kind: ArchivePathKind) -> Result<(), RehomeError> {
         let key = portable_collision_key(path);
-        if self.entries.contains_key(&key) {
-            return Err(package_invalid("portable archive path collision"));
+        if let Some(existing) = self.entries.get(&key) {
+            return Err(package_invalid(format!(
+                "portable archive path collision at {path}: {kind:?} conflicts with {existing:?}"
+            )));
         }
         for ancestor in portable_ancestors(&key) {
             if self.entries.get(ancestor) == Some(&ArchivePathKind::File) {
@@ -954,7 +956,26 @@ fn stage_discovered_trees(
         roots.insert(canonical, bundle_root.to_path_buf());
     }
 
-    for bundle_root in roots.values() {
+    let mut roots = roots.into_iter().collect::<Vec<_>>();
+    roots.sort_by(|left, right| {
+        left.0
+            .components()
+            .count()
+            .cmp(&right.0.components().count())
+            .then(left.0.cmp(&right.0))
+    });
+    let mut selected_roots = Vec::new();
+    for candidate in roots {
+        if selected_roots
+            .iter()
+            .any(|(selected, _): &(PathBuf, PathBuf)| candidate.0.starts_with(selected))
+        {
+            continue;
+        }
+        selected_roots.push(candidate);
+    }
+
+    for (_, bundle_root) in &selected_roots {
         let bundle_relative = bundle_root
             .strip_prefix(source_root)
             .map_err(|_| package_invalid("discovered Codex bundle escapes its expected root"))?;
@@ -988,7 +1009,7 @@ fn stage_discovered_trees(
             stage_source(entry.path(), staging_root, payloads, &archive_path)?;
         }
     }
-    Ok(roots.len() as u64)
+    Ok(selected_roots.len() as u64)
 }
 
 fn stage_source(

--- a/desktop/src-tauri/src/workflow.rs
+++ b/desktop/src-tauri/src/workflow.rs
@@ -27,7 +27,7 @@ use std::{
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, State, WebviewWindow};
 use tauri_plugin_dialog::{DialogExt, FilePath};
 use tauri_plugin_opener::OpenerExt;
 use uuid::Uuid;
@@ -449,6 +449,7 @@ pub async fn discover_codex(
 #[tauri::command]
 pub async fn create_package(
     app: AppHandle,
+    window: WebviewWindow,
     state: State<'_, WorkflowState>,
     selection: CreatePackageSelection,
 ) -> Result<Option<CreatedPackage>, RehomeError> {
@@ -457,6 +458,7 @@ pub async fn create_package(
         let Some(selected) = app
             .dialog()
             .file()
+            .set_parent(&window)
             .set_title("保存 ReHome 包")
             .set_file_name("handoff.rehome")
             .add_filter("ReHome 包", &["rehome"])
@@ -484,6 +486,7 @@ pub async fn create_package(
 #[tauri::command]
 pub async fn inspect_package(
     app: AppHandle,
+    window: WebviewWindow,
     state: State<'_, WorkflowState>,
 ) -> Result<Option<InspectedPackage>, RehomeError> {
     let state = state.inner().clone();
@@ -491,6 +494,7 @@ pub async fn inspect_package(
         let Some(selected) = app
             .dialog()
             .file()
+            .set_parent(&window)
             .set_title("选择 ReHome 包")
             .add_filter("ReHome 包", &["rehome"])
             .blocking_pick_file()
@@ -517,6 +521,7 @@ pub async fn inspect_package(
 #[tauri::command]
 pub async fn build_restore_plan(
     app: AppHandle,
+    window: WebviewWindow,
     state: State<'_, WorkflowState>,
     request: BuildRestorePlanRequest,
 ) -> Result<Option<BuildRestorePlanResponse>, RehomeError> {
@@ -530,6 +535,7 @@ pub async fn build_restore_plan(
             let Some(projects) = app
                 .dialog()
                 .file()
+                .set_parent(&window)
                 .set_title("选择项目目录")
                 .blocking_pick_folder()
             else {

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ReHome Desktop",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "identifier": "com.calebycj.rehome",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src-tauri/tests/discovery_test.rs
+++ b/desktop/src-tauri/tests/discovery_test.rs
@@ -260,6 +260,12 @@ fn plugin_inventory_uses_plugin_name_and_complete_version_root() -> Result<(), B
         version_root.join("assets").join("runtime.js"),
         b"complete plugin",
     )?;
+    let nested_manifest = version_root
+        .join("skills")
+        .join("layout-library")
+        .join("manifest.json");
+    fs::create_dir_all(nested_manifest.parent().unwrap())?;
+    fs::write(&nested_manifest, b"asset manifest")?;
 
     let inventory = discover_codex_with_context(Some(codex_home), &DiscoveryContext::default())?;
     assert_eq!(inventory.plugins.len(), 1);
@@ -269,6 +275,10 @@ fn plugin_inventory_uses_plugin_name_and_complete_version_root() -> Result<(), B
         "openai-bundled/browser/1.2.3"
     );
     assert!(inventory.plugins[0].size_bytes >= b"complete plugin".len() as u64);
+    assert_eq!(
+        inventory.plugins[0].source_path,
+        version_root.join(".codex-plugin").join("plugin.json")
+    );
     Ok(())
 }
 

--- a/desktop/src-tauri/tests/local_windows_acceptance_test.rs
+++ b/desktop/src-tauri/tests/local_windows_acceptance_test.rs
@@ -1,4 +1,5 @@
 use rehome_desktop_lib::core::{
+    discovery::discover_codex,
     models::{ContentCounts, CreatePackageRequest, RestoreOptions, SourceOs, TargetInventory},
     package::{create_package, inspect_package},
     planner::build_restore_plan,
@@ -13,9 +14,54 @@ use std::{
     error::Error,
     fs,
     path::{Path, PathBuf},
-    time::Duration,
+    time::{Duration, Instant},
 };
 use tempfile::tempdir;
+
+#[test]
+#[ignore = "reads the local Codex profile and packages all optional content into a temporary file"]
+fn local_all_optional_content_package() -> Result<(), Box<dyn Error>> {
+    let inventory = discover_codex(None)?;
+    let skill_paths = inventory
+        .skills
+        .iter()
+        .map(|entry| entry.source_path.clone())
+        .collect();
+    let plugin_paths = inventory
+        .plugins
+        .iter()
+        .map(|entry| entry.source_path.clone())
+        .collect();
+    let generated_image_paths = inventory
+        .generated_images
+        .iter()
+        .map(|entry| entry.source_path.clone())
+        .collect();
+    let sandbox = tempdir()?;
+    let started = Instant::now();
+    let report = create_package(CreatePackageRequest {
+        codex_home: inventory.codex_home,
+        project_paths: vec![],
+        conversation_ids: vec![],
+        output_path: sandbox.path().join("all-optional-content.rehome"),
+        source_device_id: inventory.source_device_id,
+        skill_paths,
+        plugin_paths,
+        generated_image_paths,
+    })?;
+    let package = inspect_package(&report.package_path)?;
+    assert!(package.checksum_valid);
+    assert_eq!(package.forbidden_files_total, 0);
+    println!(
+        "Optional-content package passed in {:.2?}: {} skill(s), {} plugin(s), {} image(s), {} bytes.",
+        started.elapsed(),
+        report.counts.skills,
+        report.counts.plugins,
+        report.counts.generated_images,
+        report.bytes_written,
+    );
+    Ok(())
+}
 use uuid::Uuid;
 
 #[test]

--- a/desktop/src-tauri/tests/package_test.rs
+++ b/desktop/src-tauri/tests/package_test.rs
@@ -171,6 +171,51 @@ fn packages_selected_fixture_content_without_mutating_sources() -> Result<(), Bo
 }
 
 #[test]
+fn package_collapses_overlapping_plugin_roots() -> Result<(), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let codex_home = temp.path().join(".codex");
+    let version_root = codex_home
+        .join("plugins")
+        .join("cache")
+        .join("openai-primary-runtime")
+        .join("presentations")
+        .join("1.0.0");
+    let plugin_marker = version_root.join(".codex-plugin").join("plugin.json");
+    let nested_manifest = version_root
+        .join("skills")
+        .join("layout-library")
+        .join("manifest.json");
+    fs::create_dir_all(plugin_marker.parent().unwrap())?;
+    fs::create_dir_all(nested_manifest.parent().unwrap())?;
+    fs::write(&plugin_marker, b"{}")?;
+    fs::write(&nested_manifest, b"asset manifest")?;
+    let output = temp.path().join("overlapping-plugin-roots.rehome");
+
+    let report = create_package(CreatePackageRequest {
+        codex_home,
+        project_paths: vec![],
+        conversation_ids: vec![],
+        output_path: output.clone(),
+        source_device_id: Uuid::nil(),
+        skill_paths: vec![],
+        plugin_paths: vec![plugin_marker, nested_manifest],
+        generated_image_paths: vec![],
+    })?;
+
+    assert_eq!(report.counts.plugins, 1);
+    let preview = inspect_package(&output)?;
+    assert_eq!(
+        preview
+            .entries
+            .iter()
+            .filter(|entry| entry.ends_with("/skills/layout-library/manifest.json"))
+            .count(),
+        1
+    );
+    Ok(())
+}
+
+#[test]
 fn package_deduplicates_selected_index_rows_with_a_stable_last_row_winner(
 ) -> Result<(), Box<dyn Error>> {
     let fixture = synthetic_codex_fixture()?;

--- a/desktop/src/App.test.tsx
+++ b/desktop/src/App.test.tsx
@@ -417,6 +417,10 @@ describe("ReHome Desktop workflows", () => {
 
     expect(updateButton).toBeDisabled();
     expect(screen.getByText("请先完成当前迁移")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "正在创建迁移包。内容较多时可能需要几分钟，请保持 ReHome 打开。",
+    );
+    expect(screen.getByRole("button", { name: "正在创建 ReHome 包" })).toBeDisabled();
 
     await act(async () => pending.resolve(null));
   });

--- a/desktop/src/features/send/SendPage.tsx
+++ b/desktop/src/features/send/SendPage.tsx
@@ -262,7 +262,19 @@ export default function SendPage({
       <section className="workflow-section" aria-labelledby="send-output-title">
         <div className="section-title-row"><div><span className="step-number">3</span><h2 id="send-output-title">输出位置</h2></div></div>
         <div className="form-row"><div className="form-label"><FileArchive aria-hidden="true" /><span><strong>ReHome 包</strong><small>创建时通过系统窗口选择 .rehome 保存位置</small></span></div></div>
-        <div className="command-row"><p>{hasContent ? "选择已完成，可以创建迁移包" : "请选择需要迁移的内容"}</p><button className="command-button" type="button" disabled={!canCreate} onClick={() => void handleCreate()}>{busy ? <LoaderCircle className="spin" aria-hidden="true" /> : <PackagePlus aria-hidden="true" />}创建 ReHome 包</button></div>
+        <div className="command-row">
+          <p role={busy ? "status" : undefined}>
+            {busy
+              ? "正在创建迁移包。内容较多时可能需要几分钟，请保持 ReHome 打开。"
+              : hasContent
+                ? "选择已完成，可以创建迁移包"
+                : "请选择需要迁移的内容"}
+          </p>
+          <button className="command-button" type="button" disabled={!canCreate} onClick={() => void handleCreate()}>
+            {busy ? <LoaderCircle className="spin" aria-hidden="true" /> : <PackagePlus aria-hidden="true" />}
+            {busy ? "正在创建 ReHome 包" : "创建 ReHome 包"}
+          </button>
+        </div>
         {error && <p className="inline-state status-error" role="alert">{error}</p>}
       </section>
 


### PR DESCRIPTION
## What changed
- collapse nested plugin manifests into their owning plugin bundle
- prevent overlapping optional-content roots from producing duplicate archive paths
- attach native file pickers to the ReHome window
- show a clear long-running package status
- bump ReHome Desktop to 0.1.5

## Verification
- frontend: 28 tests passed
- Rust: full suite passed
- clippy: passed with warnings denied
- real local optional-content package: 31 skills, 15 plugins, 124 images, 295 MB, checksum valid