### PR TITLE
Retry transient source changes during packaging

### DIFF
--- a/desktop/src-tauri/src/core/package.rs
+++ b/desktop/src-tauri/src/core/package.rs
@@ -20,7 +20,7 @@ use std::{
     env, fs,
     io::{self, BufRead, BufReader, Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
-    time::SystemTime,
+    time::{Duration, SystemTime},
 };
 use tempfile::{Builder, NamedTempFile};
 use unicode_normalization::UnicodeNormalization;
@@ -37,6 +37,8 @@ const MAX_INSPECTION_BYTES: u64 = 1024 * 1024 * 1024;
 const MAX_ARCHIVE_FILE_BYTES: u64 = 2 * MAX_INSPECTION_BYTES;
 const STREAM_BUFFER_BYTES: usize = 64 * 1024;
 const MAX_JSONL_LINE_BYTES: usize = 1024 * 1024;
+const MAX_SOURCE_COPY_ATTEMPTS: usize = 3;
+const SOURCE_COPY_RETRY_DELAY: Duration = Duration::from_millis(50);
 const THREAD_EXPORT_COLUMNS_V1: &[&str] = &[
     "id",
     "cwd",
@@ -1028,6 +1030,42 @@ fn copy_source_to_staging(
     staging_root: &Path,
     archive_path: &str,
 ) -> Result<Payload, RehomeError> {
+    retry_stable_copy(source, || {
+        copy_source_to_staging_once(source, staging_root, archive_path)
+    })
+}
+
+fn retry_stable_copy<T>(
+    source: &Path,
+    mut attempt_copy: impl FnMut() -> Result<StableCopyAttempt<T>, RehomeError>,
+) -> Result<T, RehomeError> {
+    for attempt in 1..=MAX_SOURCE_COPY_ATTEMPTS {
+        match attempt_copy()? {
+            StableCopyAttempt::Complete(payload) => return Ok(payload),
+            StableCopyAttempt::Changed if attempt < MAX_SOURCE_COPY_ATTEMPTS => {
+                std::thread::sleep(SOURCE_COPY_RETRY_DELAY);
+            }
+            StableCopyAttempt::Changed => {
+                return Err(package_invalid(format!(
+                    "source file kept changing while being copied after {MAX_SOURCE_COPY_ATTEMPTS} attempts: {}",
+                    source.display()
+                )));
+            }
+        }
+    }
+    unreachable!("source copy attempts are nonzero")
+}
+
+enum StableCopyAttempt<T> {
+    Complete(T),
+    Changed,
+}
+
+fn copy_source_to_staging_once(
+    source: &Path,
+    staging_root: &Path,
+    archive_path: &str,
+) -> Result<StableCopyAttempt<Payload>, RehomeError> {
     let before = source_fingerprint(source)?;
     if before.length > MAX_ARCHIVE_ENTRY_BYTES {
         return Err(package_invalid(
@@ -1044,14 +1082,13 @@ fn copy_source_to_staging(
     writer.sync_all().map_err(io_package_error)?;
     drop(writer);
     if before != source_fingerprint(source)? {
-        return Err(package_invalid(
-            "source file changed in size or modification time while being copied",
-        ));
+        fs::remove_file(&destination).map_err(io_package_error)?;
+        return Ok(StableCopyAttempt::Changed);
     }
-    Ok(Payload {
+    Ok(StableCopyAttempt::Complete(Payload {
         hash,
         executable: source_is_executable(source),
-    })
+    }))
 }
 
 fn stage_generated(
@@ -1435,6 +1472,24 @@ mod authenticated_payload_tests {
         let error = authenticate_payload_bytes(b"tampered bytes", &verified).unwrap_err();
 
         assert_eq!(error.code, ErrorCode::ChecksumMismatch);
+    }
+
+    #[test]
+    fn stable_copy_retries_a_transient_source_change() {
+        let mut attempts = 0;
+
+        let copied = retry_stable_copy(Path::new("volatile-source"), || {
+            attempts += 1;
+            if attempts == 1 {
+                Ok(StableCopyAttempt::Changed)
+            } else {
+                Ok(StableCopyAttempt::Complete("stable"))
+            }
+        })
+        .unwrap();
+
+        assert_eq!(copied, "stable");
+        assert_eq!(attempts, 2);
     }
 }
 

--- a/desktop/src/App.test.tsx
+++ b/desktop/src/App.test.tsx
@@ -397,6 +397,26 @@ describe("ReHome Desktop workflows", () => {
     });
   });
 
+  it("reveals a newly created package so the user can find it", async () => {
+    const user = userEvent.setup();
+    api.createPackage.mockResolvedValue({
+      package_path: "C:\\Transfers\\handoff.rehome",
+      package_id: "56565656-5656-4656-8656-565656565656",
+      bytes_written: 4096,
+      counts: preview.manifest.counts,
+      archive_hash: "created-package-hash",
+      reveal_id: "57575757-5757-4757-8757-575757575757",
+    });
+    render(<App />);
+    await screen.findByText(inventory.codex_home);
+    await user.click(screen.getByRole("button", { name: "前往发送" }));
+    await user.click(screen.getByRole("checkbox", { name: "选择项目 rehome-app" }));
+    await user.click(screen.getByRole("button", { name: "创建 ReHome 包" }));
+
+    expect(api.openPath).toHaveBeenCalledWith("57575757-5757-4757-8757-575757575757");
+    expect(screen.getByText("C:\\Transfers\\handoff.rehome")).toBeInTheDocument();
+  });
+
   it("blocks update installation while a migration package is being created", async () => {
     const user = userEvent.setup();
     const pending = deferred<null>();

--- a/desktop/src/features/send/SendPage.tsx
+++ b/desktop/src/features/send/SendPage.tsx
@@ -145,9 +145,21 @@ export default function SendPage({
         plugin_ids: [...plugins],
         generated_image_ids: [...images],
       });
-      if (created) setReport(created);
+      if (created) {
+        setReport(created);
+        try {
+          await openPath(created.reveal_id);
+        } catch {
+          setError(`迁移包已创建在：${created.package_path}\n但没能自动打开所在文件夹。`);
+        }
+      }
     } catch (caught) {
-      setError(errorMessage(caught));
+      const message = errorMessage(caught);
+      setError(
+        message.includes("source file kept changing while being copied")
+          ? `有文件在打包过程中仍被修改。请稍等几秒后重试；如果反复出现，请先完全退出 Codex。\n${message}`
+          : message,
+      );
     } finally {
       setBusy(false);
       onOperationEnd();


### PR DESCRIPTION
## Fixes
- retry files that change briefly while Codex updates them
- continue rejecting files that remain unstable after three verified attempts
- show a clear Chinese recovery message with the exact source path
- reveal the generated .rehome file automatically after success

## Verification
- 29 frontend tests passed
- full Rust suite passed
- clippy passed with warnings denied
- real local package passed: 31 skills, 15 plugins, 124 images, 295 MB, checksum valid