### PR TITLE
Harden updater release and migration interlock

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   test:
@@ -141,6 +141,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/desktop-v')
     needs: [windows-installer, macos-installer]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rehome-desktop",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rehome-desktop",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-process": "^2.3.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rehome-desktop",
   "private": true,
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2886,7 +2886,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rehome-desktop"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rehome-desktop"
-version = "0.1.5"
+version = "0.1.6"
 description = "ReHome Desktop migration utility"
 authors = ["ReHome contributors"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ReHome Desktop",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "identifier": "com.calebycj.rehome",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/App.test.tsx
+++ b/desktop/src/App.test.tsx
@@ -445,6 +445,31 @@ describe("ReHome Desktop workflows", () => {
     await act(async () => pending.resolve(null));
   });
 
+  it("blocks migration controls while an update is being installed", async () => {
+    const user = userEvent.setup();
+    const pending = deferred<void>();
+    updater.checkForUpdates.mockResolvedValue({
+      status: "available",
+      currentVersion: "0.1.4",
+      version: "0.1.5",
+      notes: null,
+    });
+    updater.installCheckedUpdate.mockReturnValue(pending.promise);
+    render(<App />);
+    await screen.findByText(inventory.codex_home);
+
+    const updateButton = await screen.findByRole("button", { name: /0\.1\.5/ });
+    await user.click(updateButton);
+
+    const workspace = document.querySelector("main.workspace");
+    expect(workspace).toHaveAttribute("inert");
+    expect(workspace).toHaveAttribute("aria-busy", "true");
+
+    await act(async () => pending.reject(new Error("download failed")));
+    expect(workspace).not.toHaveAttribute("inert");
+    expect(workspace).toHaveAttribute("aria-busy", "false");
+  });
+
   it("lists optional content and packages only the selected entries", async () => {
     const user = userEvent.setup();
     render(<App />);
@@ -801,8 +826,10 @@ function restoreReportWithRegistration(status: "manual_open_required") {
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
     resolve = resolvePromise;
+    reject = rejectPromise;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -46,6 +46,7 @@ export default function App() {
   const [loading, setLoading] = useState(true);
   const [discoveryError, setDiscoveryError] = useState<string | null>(null);
   const [activeOperations, setActiveOperations] = useState(0);
+  const [updateInstalling, setUpdateInstalling] = useState(false);
   const headingRef = useRef<HTMLHeadingElement>(null);
   const previousViewRef = useRef(view);
 
@@ -111,14 +112,22 @@ export default function App() {
           ))}
         </nav>
 
-        <UpdateControl migrationBusy={activeOperations > 0} />
+        <UpdateControl
+          migrationBusy={activeOperations > 0}
+          onInstallingChange={setUpdateInstalling}
+        />
         <div className="sidebar-meta">
           <Laptop aria-hidden="true" />
           <span>离线本机迁移</span>
         </div>
       </aside>
 
-      <main className="workspace" data-view={view}>
+      <main
+        className="workspace"
+        data-view={view}
+        inert={updateInstalling ? true : undefined}
+        aria-busy={updateInstalling}
+      >
         <header className="topbar">
           <span className="topbar-title">{viewTitles[view]}</span>
           {loading ? (

--- a/desktop/src/features/update/UpdateControl.test.tsx
+++ b/desktop/src/features/update/UpdateControl.test.tsx
@@ -25,7 +25,7 @@ describe("UpdateControl", () => {
 
   it("checks automatically and installs a signed update after confirmation", async () => {
     const user = userEvent.setup();
-    render(<UpdateControl migrationBusy={false} />);
+    render(<UpdateControl migrationBusy={false} onInstallingChange={vi.fn()} />);
 
     const install = await screen.findByRole("button", { name: "更新到 0.1.4" });
     expect(screen.getByText("当前 0.1.3")).toBeInTheDocument();
@@ -37,7 +37,7 @@ describe("UpdateControl", () => {
   });
 
   it("blocks installation while a migration operation is active", async () => {
-    render(<UpdateControl migrationBusy />);
+    render(<UpdateControl migrationBusy onInstallingChange={vi.fn()} />);
 
     const install = await screen.findByRole("button", { name: "更新到 0.1.4" });
     expect(install).toBeDisabled();
@@ -49,7 +49,7 @@ describe("UpdateControl", () => {
     updater.checkForUpdates
       .mockRejectedValueOnce(new Error("offline"))
       .mockResolvedValueOnce({ status: "current", currentVersion: "0.1.4" });
-    render(<UpdateControl migrationBusy={false} />);
+    render(<UpdateControl migrationBusy={false} onInstallingChange={vi.fn()} />);
 
     const retry = await screen.findByRole("button", { name: "重新检查更新" });
     expect(screen.getByText("检查失败，不影响离线迁移")).toBeInTheDocument();

--- a/desktop/src/features/update/UpdateControl.tsx
+++ b/desktop/src/features/update/UpdateControl.tsx
@@ -9,6 +9,7 @@ import {
 
 interface UpdateControlProps {
   migrationBusy: boolean;
+  onInstallingChange: (installing: boolean) => void;
 }
 
 type UpdateState =
@@ -18,7 +19,7 @@ type UpdateState =
   | { phase: "installed" }
   | { phase: "error" };
 
-export default function UpdateControl({ migrationBusy }: UpdateControlProps) {
+export default function UpdateControl({ migrationBusy, onInstallingChange }: UpdateControlProps) {
   const [state, setState] = useState<UpdateState>({ phase: "checking" });
 
   const runCheck = useCallback(async () => {
@@ -36,6 +37,7 @@ export default function UpdateControl({ migrationBusy }: UpdateControlProps) {
 
   async function install(result: Extract<UpdateCheckResult, { status: "available" }>) {
     if (migrationBusy) return;
+    onInstallingChange(true);
     setState({ phase: "installing", result, percent: null });
     try {
       await installCheckedUpdate(({ percent }) => {
@@ -43,6 +45,7 @@ export default function UpdateControl({ migrationBusy }: UpdateControlProps) {
       });
       setState({ phase: "installed" });
     } catch {
+      onInstallingChange(false);
       setState({ phase: "error" });
     }
   }

--- a/scripts/generate-updater-json.mjs
+++ b/scripts/generate-updater-json.mjs
@@ -11,6 +11,18 @@ if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) {
   throw new Error(`Unsupported release tag: ${tag}`);
 }
 
+const packageVersion = JSON.parse(
+  readFileSync(resolve("desktop/package.json"), "utf8"),
+).version;
+const tauriVersion = JSON.parse(
+  readFileSync(resolve("desktop/src-tauri/tauri.conf.json"), "utf8"),
+).version;
+if (packageVersion !== version || tauriVersion !== version) {
+  throw new Error(
+    `Release tag version ${version} does not match package version ${packageVersion} and Tauri version ${tauriVersion}`,
+  );
+}
+
 const assetsDirectory = resolve(assetsArgument);
 const files = readdirSync(assetsDirectory);
 const windowsBundle = findOne(files, (name) => name.endsWith("-setup.exe"), "Windows updater");

--- a/scripts/generate-updater-json.test.mjs
+++ b/scripts/generate-updater-json.test.mjs
@@ -8,7 +8,8 @@ import test from "node:test";
 test("generates one manifest for Windows and both Universal macOS architectures", () => {
   const directory = mkdtempSync(join(tmpdir(), "rehome-updater-manifest-"));
   try {
-    const windows = "ReHome Desktop_0.1.4_x64-setup.exe";
+    const appVersion = JSON.parse(readFileSync(resolve("desktop/package.json"), "utf8")).version;
+    const windows = `ReHome Desktop_${appVersion}_x64-setup.exe`;
     const mac = "ReHome Desktop.app.tar.gz";
     writeFileSync(join(directory, windows), "windows");
     writeFileSync(join(directory, `${windows}.sig`), "windows-signature\n");
@@ -18,13 +19,13 @@ test("generates one manifest for Windows and both Universal macOS architectures"
     const script = resolve("scripts/generate-updater-json.mjs");
     const result = spawnSync(
       process.execPath,
-      [script, directory, "desktop-v0.1.4", "CalebYcj/codex-rehome"],
+      [script, directory, `desktop-v${appVersion}`, "CalebYcj/codex-rehome"],
       { encoding: "utf8" },
     );
     assert.equal(result.status, 0, result.stderr);
 
     const manifest = JSON.parse(readFileSync(join(directory, "latest.json"), "utf8"));
-    assert.equal(manifest.version, "0.1.4");
+    assert.equal(manifest.version, appVersion);
     assert.equal(manifest.platforms["windows-x86_64"].signature, "windows-signature");
     assert.equal(manifest.platforms["darwin-x86_64"].signature, "mac-signature");
     assert.deepEqual(
@@ -34,6 +35,23 @@ test("generates one manifest for Windows and both Universal macOS architectures"
     assert.match(manifest.platforms["windows-x86_64"].url, /ReHome\.Desktop/);
     assert.doesNotMatch(manifest.platforms["windows-x86_64"].url, /%20/);
     assert.match(manifest.platforms["darwin-x86_64"].url, /ReHome\.Desktop\.app\.tar\.gz$/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("rejects a release tag that does not match the app version", () => {
+  const directory = mkdtempSync(join(tmpdir(), "rehome-updater-version-"));
+  try {
+    const script = resolve("scripts/generate-updater-json.mjs");
+    const result = spawnSync(
+      process.execPath,
+      [script, directory, "desktop-v99.0.0", "CalebYcj/codex-rehome"],
+      { encoding: "utf8" },
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /does not match package version/);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- block migration controls while a signed update is installing
- restrict GitHub write permission to the release job only
- reject release tags that do not match both application version sources
- prepare ReHome Desktop v0.1.6

## Verification
- 30 frontend tests
- full Rust test suite
- clippy with warnings denied
- production frontend build
- updater manifest tests
- npm production audit: 0 vulnerabilities