### PR TITLE
Speed up large restores and harden Windows packaging

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rehome-desktop",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rehome-desktop",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-process": "^2.3.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rehome-desktop",
   "private": true,
-  "version": "0.1.13",
+  "version": "0.1.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2886,7 +2886,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rehome-desktop"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rehome-desktop"
-version = "0.1.13"
+version = "0.1.14"
 description = "ReHome Desktop migration utility"
 authors = ["ReHome contributors"]
 edition = "2021"

--- a/desktop/src-tauri/src/core/backup.rs
+++ b/desktop/src-tauri/src/core/backup.rs
@@ -23,6 +23,8 @@ use uuid::Uuid;
 
 const APP_IDENTIFIER: &str = "com.rehome.desktop";
 const TRANSACTIONS_DIRECTORY: &str = "transactions";
+const APPLIED_CHECKPOINTS_DIRECTORY: &str = "applied";
+const MAX_APPLIED_CHECKPOINT_BYTES: u64 = 64 * 1024;
 const SQLITE_SIDECARS: &[&str] = &["-wal", "-shm", "-journal"];
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -97,6 +99,17 @@ pub(crate) struct TransactionJournal {
 pub(crate) struct PreparedTransaction {
     pub journal: TransactionJournal,
     pub journal_path: PathBuf,
+    applied_checkpoints: PathBuf,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct AppliedCheckpoint {
+    operation_index: usize,
+    package_source: String,
+    target: PathBuf,
+    applied_hash: Option<String>,
+    applied_state: AppliedState,
+    applied_database_hash: Option<String>,
 }
 
 pub(crate) fn prepare_transaction(
@@ -140,6 +153,12 @@ pub(crate) fn prepare_transaction(
     let objects = transaction_backup.join("objects");
     fs::create_dir(&objects)
         .map_err(|error| restore_failed(format!("could not create backup objects: {error}")))?;
+    let applied_checkpoints = transaction_backup.join(APPLIED_CHECKPOINTS_DIRECTORY);
+    fs::create_dir(&applied_checkpoints).map_err(|error| {
+        restore_failed(format!(
+            "could not create applied checkpoint directory: {error}"
+        ))
+    })?;
     sync_directory(&transaction_backup)
         .map_err(|error| restore_failed(format!("could not sync backup directory: {error}")))?;
 
@@ -219,6 +238,7 @@ pub(crate) fn prepare_transaction(
     Ok(PreparedTransaction {
         journal,
         journal_path,
+        applied_checkpoints,
     })
 }
 
@@ -262,7 +282,7 @@ pub(crate) fn record_applied_mutation(
                 .map(|(index, _)| index),
         );
     }
-    for index in indices {
+    for &index in &indices {
         let operation = &prepared.journal.operations[index];
         let applied_state = inspect_applied_state(operation)?;
         prepared.journal.operations[index].applied_hash = match &applied_state {
@@ -285,7 +305,54 @@ pub(crate) fn record_applied_mutation(
             }
         }
     }
-    write_journal(&prepared.journal_path, &prepared.journal)
+    for index in indices {
+        write_applied_checkpoint(&prepared.applied_checkpoints, &prepared.journal, index)?;
+    }
+    Ok(())
+}
+
+fn write_applied_checkpoint(
+    directory: &Path,
+    journal: &TransactionJournal,
+    operation_index: usize,
+) -> Result<(), RehomeError> {
+    let operation = journal
+        .operations
+        .get(operation_index)
+        .ok_or_else(|| restore_failed("applied checkpoint operation is missing"))?;
+    let applied_state = operation
+        .applied_state
+        .clone()
+        .ok_or_else(|| restore_failed("applied checkpoint has no applied state"))?;
+    let checkpoint = AppliedCheckpoint {
+        operation_index,
+        package_source: operation.package_source.clone(),
+        target: operation.target.clone(),
+        applied_hash: operation.applied_hash.clone(),
+        applied_state,
+        applied_database_hash: operation.applied_database_hash.clone(),
+    };
+    let mut bytes = serde_json::to_vec(&checkpoint)
+        .map_err(|error| restore_failed(format!("could not encode applied checkpoint: {error}")))?;
+    bytes.push(b'\n');
+    if bytes.len() as u64 > MAX_APPLIED_CHECKPOINT_BYTES {
+        return Err(restore_failed(
+            "applied checkpoint exceeds the safety limit",
+        ));
+    }
+    validate_directory_entry(directory)?;
+    let pinned = PinnedParent::open(directory).map_err(|error| {
+        restore_failed(format!(
+            "could not pin applied checkpoint directory: {error}"
+        ))
+    })?;
+    let name = format!("{operation_index:08}.json");
+    pinned
+        .replace_bytes(std::ffi::OsStr::new(&name), &bytes)
+        .map_err(|error| restore_failed(format!("could not write applied checkpoint: {error}")))?;
+    pinned
+        .sync()
+        .map_err(|error| restore_failed(format!("could not sync applied checkpoint: {error}")))
 }
 
 pub(crate) fn ensure_applied_states(prepared: &PreparedTransaction) -> Result<(), RehomeError> {
@@ -1424,7 +1491,7 @@ fn load_validated_journal(
     }
     let bytes = fs::read(path)
         .map_err(|error| rollback_failed(format!("could not read transaction journal: {error}")))?;
-    let journal: TransactionJournal = serde_json::from_slice(&bytes)
+    let mut journal: TransactionJournal = serde_json::from_slice(&bytes)
         .map_err(|error| rollback_failed(format!("transaction journal is invalid: {error}")))?;
     if expected_id.is_some_and(|expected| journal.transaction_id != expected) {
         return Err(rollback_failed(
@@ -1438,7 +1505,105 @@ fn load_validated_journal(
         ));
     }
     validate_journal(&journal)?;
+    load_applied_checkpoints(&mut journal)?;
     Ok(journal)
+}
+
+fn load_applied_checkpoints(journal: &mut TransactionJournal) -> Result<(), RehomeError> {
+    let directory = journal
+        .backup_root
+        .join(journal.transaction_id.to_string())
+        .join(APPLIED_CHECKPOINTS_DIRECTORY);
+    let metadata = match fs::symlink_metadata(&directory) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(rollback_failed(format!(
+                "could not inspect applied checkpoint directory: {error}"
+            )))
+        }
+    };
+    if metadata_is_link_or_reparse(&metadata) || !metadata.is_dir() {
+        return Err(rollback_failed("applied checkpoint directory is unsafe"));
+    }
+    let canonical = fs::canonicalize(&directory).map_err(|error| {
+        rollback_failed(format!(
+            "could not resolve applied checkpoint directory: {error}"
+        ))
+    })?;
+    let transaction_root = fs::canonicalize(
+        journal.backup_root.join(journal.transaction_id.to_string()),
+    )
+    .map_err(|error| rollback_failed(format!("could not resolve transaction backup: {error}")))?;
+    if !canonical.starts_with(&transaction_root) {
+        return Err(rollback_failed(
+            "applied checkpoint directory escapes the transaction backup",
+        ));
+    }
+
+    for entry in fs::read_dir(&directory).map_err(|error| {
+        rollback_failed(format!("could not enumerate applied checkpoints: {error}"))
+    })? {
+        let entry = entry.map_err(|error| {
+            rollback_failed(format!("could not inspect applied checkpoint: {error}"))
+        })?;
+        let path = entry.path();
+        let metadata = fs::symlink_metadata(&path).map_err(|error| {
+            rollback_failed(format!("could not inspect applied checkpoint: {error}"))
+        })?;
+        if metadata_is_link_or_reparse(&metadata)
+            || !metadata.is_file()
+            || metadata.len() > MAX_APPLIED_CHECKPOINT_BYTES
+        {
+            return Err(rollback_failed("applied checkpoint is unsafe"));
+        }
+        let file_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| rollback_failed("applied checkpoint name is invalid"))?;
+        let index_text = file_name
+            .strip_suffix(".json")
+            .filter(|value| value.len() == 8 && value.bytes().all(|byte| byte.is_ascii_digit()))
+            .ok_or_else(|| rollback_failed("applied checkpoint name is invalid"))?;
+        let operation_index = index_text
+            .parse::<usize>()
+            .map_err(|_| rollback_failed("applied checkpoint index is invalid"))?;
+        let bytes = fs::read(&path).map_err(|error| {
+            rollback_failed(format!("could not read applied checkpoint: {error}"))
+        })?;
+        let checkpoint: AppliedCheckpoint = serde_json::from_slice(&bytes)
+            .map_err(|error| rollback_failed(format!("applied checkpoint is invalid: {error}")))?;
+        if checkpoint.operation_index != operation_index {
+            return Err(rollback_failed(
+                "applied checkpoint index does not match its name",
+            ));
+        }
+        let operation = journal
+            .operations
+            .get_mut(operation_index)
+            .ok_or_else(|| rollback_failed("applied checkpoint operation is out of range"))?;
+        if checkpoint.package_source != operation.package_source
+            || checkpoint.target != operation.target
+        {
+            return Err(rollback_failed(
+                "applied checkpoint does not match its transaction operation",
+            ));
+        }
+        let expected_hash = match &checkpoint.applied_state {
+            AppliedState::File { hash, .. } => Some(hash.clone()),
+            AppliedState::Absent => None,
+        };
+        if checkpoint.applied_hash != expected_hash {
+            return Err(rollback_failed("applied checkpoint hash is inconsistent"));
+        }
+        // A checkpoint is written after the corresponding mutation. It can be
+        // newer than the last phase-level journal snapshot, especially when
+        // SQLite creates or refreshes WAL sidecars during verification.
+        operation.applied_hash = checkpoint.applied_hash;
+        operation.applied_state = Some(checkpoint.applied_state);
+        operation.applied_database_hash = checkpoint.applied_database_hash;
+    }
+    Ok(())
 }
 
 fn validate_journal(journal: &TransactionJournal) -> Result<(), RehomeError> {

--- a/desktop/src-tauri/src/core/legacy.rs
+++ b/desktop/src-tauri/src/core/legacy.rs
@@ -64,6 +64,12 @@ struct ProjectSource {
 }
 
 pub(crate) fn inspect_schema_v3(path: &Path) -> Result<Option<VerifiedPackage>, RehomeError> {
+    let archive_metadata = fs::metadata(path)
+        .map_err(|error| invalid(format!("could not inspect package: {error}")))?;
+    let archive_size_bytes = archive_metadata.len();
+    let archive_modified = archive_metadata
+        .modified()
+        .map_err(|error| invalid(format!("could not inspect package: {error}")))?;
     let mut file = fs::File::open(path)
         .map_err(|error| invalid(format!("could not open package: {error}")))?;
     let archive_hash = hash_file(&mut file)?;
@@ -309,6 +315,8 @@ pub(crate) fn inspect_schema_v3(path: &Path) -> Result<Option<VerifiedPackage>, 
         },
         payloads,
         planning_payloads,
+        archive_size_bytes,
+        archive_modified,
     }))
 }
 

--- a/desktop/src-tauri/src/core/package.rs
+++ b/desktop/src-tauri/src/core/package.rs
@@ -255,6 +255,13 @@ pub(crate) struct VerifiedPackage {
     pub preview: PackagePreview,
     pub payloads: BTreeMap<String, VerifiedPayload>,
     pub planning_payloads: BTreeMap<String, Vec<u8>>,
+    pub(crate) archive_size_bytes: u64,
+    pub(crate) archive_modified: SystemTime,
+}
+
+pub(crate) struct AuthenticatedPayloadArchive<'a> {
+    verified: &'a VerifiedPackage,
+    archive: ZipArchive<fs::File>,
 }
 
 impl VerifiedPackage {
@@ -279,15 +286,19 @@ impl VerifiedPackage {
         Ok(bytes)
     }
 
-    pub(crate) fn write_authenticated_payload<W: Write>(
+    pub(crate) fn open_payload_archive(
         &self,
-        source: &str,
-        writer: &mut W,
-    ) -> Result<u64, RehomeError> {
-        let verified = self
-            .payloads
-            .get(source)
-            .ok_or_else(|| package_invalid("restore operation references a missing payload"))?;
+    ) -> Result<AuthenticatedPayloadArchive<'_>, RehomeError> {
+        let metadata = fs::metadata(&self.preview.package_path)
+            .map_err(|error| package_invalid(format!("could not inspect package: {error}")))?;
+        if !metadata.is_file()
+            || metadata.len() != self.archive_size_bytes
+            || metadata.modified().map_err(io_package_error)? != self.archive_modified
+        {
+            return Err(package_invalid(
+                "package archive changed after restore planning",
+            ));
+        }
         let mut file = fs::File::open(&self.preview.package_path)
             .map_err(|error| package_invalid(format!("could not reopen package: {error}")))?;
         let archive_hash = hash_archive_file(&mut file)?;
@@ -296,17 +307,35 @@ impl VerifiedPackage {
                 "package archive changed after restore planning",
             ));
         }
+        file.seek(SeekFrom::Start(0))
+            .map_err(|error| package_invalid(format!("could not rewind package: {error}")))?;
+        let archive = ZipArchive::new(file)
+            .map_err(|error| package_invalid(format!("invalid ZIP container: {error}")))?;
+        Ok(AuthenticatedPayloadArchive {
+            verified: self,
+            archive,
+        })
+    }
+}
+
+impl AuthenticatedPayloadArchive<'_> {
+    pub(crate) fn write_payload<W: Write>(
+        &mut self,
+        source: &str,
+        writer: &mut W,
+    ) -> Result<u64, RehomeError> {
+        let verified = self
+            .verified
+            .payloads
+            .get(source)
+            .ok_or_else(|| package_invalid("restore operation references a missing payload"))?;
         if let Some(bytes) = verified.inline_bytes.as_ref() {
             authenticate_payload_bytes(bytes, verified)?;
             writer.write_all(bytes).map_err(io_package_error)?;
             return Ok(bytes.len() as u64);
         }
-        file.seek(SeekFrom::Start(0))
-            .map_err(|error| package_invalid(format!("could not rewind package: {error}")))?;
-        let mut archive = ZipArchive::new(file)
-            .map_err(|error| package_invalid(format!("invalid ZIP container: {error}")))?;
         let archive_name = verified.archive_name.as_deref().unwrap_or(source);
-        let mut entry = archive.by_name(archive_name).map_err(|error| {
+        let mut entry = self.archive.by_name(archive_name).map_err(|error| {
             package_invalid(format!(
                 "could not reopen verified payload {source}: {error}"
             ))
@@ -326,6 +355,10 @@ pub(crate) fn inspect_package_for_planning(path: &Path) -> Result<VerifiedPackag
     if let Some(package) = crate::core::legacy::inspect_schema_v3(path)? {
         return Ok(package);
     }
+    let archive_metadata = fs::metadata(path)
+        .map_err(|error| package_invalid(format!("could not inspect package: {error}")))?;
+    let archive_size_bytes = archive_metadata.len();
+    let archive_modified = archive_metadata.modified().map_err(io_package_error)?;
     let mut file = fs::File::open(path)
         .map_err(|error| package_invalid(format!("could not open package: {error}")))?;
     let archive_hash = hash_archive_file(&mut file)?;
@@ -480,6 +513,8 @@ pub(crate) fn inspect_package_for_planning(path: &Path) -> Result<VerifiedPackag
         },
         payloads,
         planning_payloads,
+        archive_size_bytes,
+        archive_modified,
     })
 }
 

--- a/desktop/src-tauri/src/core/package.rs
+++ b/desktop/src-tauri/src/core/package.rs
@@ -41,8 +41,10 @@ const MAX_ARCHIVE_ENTRY_BYTES: u64 = MAX_INSPECTION_BYTES;
 const MAX_ARCHIVE_FILE_BYTES: u64 = 2 * MAX_INSPECTION_BYTES;
 const STREAM_BUFFER_BYTES: usize = 64 * 1024;
 const MAX_JSONL_LINE_BYTES: usize = 1024 * 1024;
-const MAX_SOURCE_COPY_ATTEMPTS: usize = 3;
-const SOURCE_COPY_RETRY_DELAY: Duration = Duration::from_millis(50);
+// Codex keeps updating its session index while the app is open. Give a
+// transient write enough time to settle before treating it as a failed pack.
+const MAX_SOURCE_COPY_ATTEMPTS: usize = 8;
+const SOURCE_COPY_RETRY_DELAY: Duration = Duration::from_millis(200);
 const THREAD_EXPORT_COLUMNS_V1: &[&str] = &[
     "id",
     "cwd",
@@ -771,6 +773,15 @@ fn read_selected_session_index(
     let Some(path) = path else {
         return Ok(SessionIndexMetadata::default());
     };
+    retry_stable_copy(path, || {
+        read_selected_session_index_once(path, selected_ids)
+    })
+}
+
+fn read_selected_session_index_once(
+    path: &Path,
+    selected_ids: &[Uuid],
+) -> Result<StableCopyAttempt<SessionIndexMetadata>, RehomeError> {
     let selected: HashSet<Uuid> = selected_ids.iter().copied().collect();
     let mut result = SessionIndexMetadata::default();
     let before = source_fingerprint(path)?;
@@ -794,11 +805,9 @@ fn read_selected_session_index(
         }
     }
     if before != source_fingerprint(path)? {
-        return Err(package_invalid(
-            "source file changed in size or modification time while being read",
-        ));
+        return Ok(StableCopyAttempt::Changed);
     }
-    Ok(result)
+    Ok(StableCopyAttempt::Complete(result))
 }
 
 fn export_selected_threads(
@@ -1051,7 +1060,7 @@ fn retry_stable_copy<T>(
             }
             StableCopyAttempt::Changed => {
                 return Err(package_invalid(format!(
-                    "source file kept changing while being copied after {MAX_SOURCE_COPY_ATTEMPTS} attempts: {}",
+                    "source file kept changing while being packaged after {MAX_SOURCE_COPY_ATTEMPTS} attempts: {}; close Codex or retry after it finishes saving",
                     source.display()
                 )));
             }

--- a/desktop/src-tauri/src/core/restore.rs
+++ b/desktop/src-tauri/src/core/restore.rs
@@ -255,6 +255,7 @@ fn apply_regular_files(
 ) -> Result<(u64, u64), RehomeError> {
     let mut restored_files = 0_u64;
     let mut restored_bytes = 0_u64;
+    let mut payload_archive = verified.open_payload_archive()?;
     for operation in &plan.operations {
         if !matches!(operation.action, ChangeKind::Add | ChangeKind::Update)
             || is_bridge_operation(plan, &operation.package_source)
@@ -264,8 +265,8 @@ fn apply_regular_files(
         let mut staged = NamedTempFile::new().map_err(|error| {
             restore_failed(format!("could not stage restored payload: {error}"))
         })?;
-        let bytes = verified
-            .write_authenticated_payload(&operation.package_source, staged.as_file_mut())?;
+        let bytes =
+            payload_archive.write_payload(&operation.package_source, staged.as_file_mut())?;
         staged.as_file().sync_all().map_err(|error| {
             restore_failed(format!("could not flush restored payload: {error}"))
         })?;

--- a/desktop/src-tauri/src/core/stable_fs.rs
+++ b/desktop/src-tauri/src/core/stable_fs.rs
@@ -129,6 +129,33 @@ mod tests {
         assert_eq!(fs::read(outside.join("remove")).unwrap(), b"outside");
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn windows_pinned_replace_supports_paths_longer_than_max_path() {
+        let root = tempfile::tempdir().unwrap();
+        let long_component = "a".repeat(170);
+        let parent = root.path().join(long_component);
+        fs::create_dir(&parent).unwrap();
+        let target_name = format!("{}-target.txt", "b".repeat(80));
+        let target = parent.join(&target_name);
+        assert!(target.as_os_str().to_string_lossy().len() > 260);
+        let pinned = PinnedParent::open(&parent).unwrap();
+
+        pinned
+            .replace_bytes(OsStr::new(&target_name), b"long path works")
+            .unwrap();
+
+        assert_eq!(
+            pinned
+                .open_file(OsStr::new(&target_name))
+                .unwrap()
+                .metadata()
+                .unwrap()
+                .len(),
+            15
+        );
+    }
+
     #[cfg(unix)]
     fn swap_parent(
         parent: &std::path::Path,
@@ -163,13 +190,6 @@ struct DirectoryIdentity {
 
 impl PinnedParent {
     pub(crate) fn open(path: &Path) -> io::Result<Self> {
-        let metadata = fs::symlink_metadata(path)?;
-        if metadata.file_type().is_symlink() || !metadata.is_dir() || is_reparse_point(&metadata) {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "mutation parent is not a regular directory",
-            ));
-        }
         let directory = open_directory(path)?;
         let identity = directory_identity(&directory)?;
         let pinned = Self {
@@ -304,10 +324,6 @@ impl PinnedParent {
     }
 
     fn verify_location(&self) -> io::Result<()> {
-        let metadata = fs::symlink_metadata(&self.path)?;
-        if metadata.file_type().is_symlink() || !metadata.is_dir() || is_reparse_point(&metadata) {
-            return Err(io::Error::other("mutation parent changed identity"));
-        }
         let current = open_directory_for_verification(&self.path)?;
         if directory_identity(&current)? != self.identity {
             return Err(io::Error::other("mutation parent changed identity"));
@@ -354,7 +370,7 @@ fn open_directory_for_verification(path: &Path) -> io::Result<fs::File> {
 
 #[cfg(windows)]
 fn open_windows_directory(path: &Path, share_delete: bool) -> io::Result<fs::File> {
-    use std::os::windows::{ffi::OsStrExt, io::FromRawHandle};
+    use std::os::windows::io::FromRawHandle;
     use windows_sys::Win32::{
         Foundation::{GENERIC_READ, GENERIC_WRITE, INVALID_HANDLE_VALUE},
         Storage::FileSystem::{
@@ -363,11 +379,7 @@ fn open_windows_directory(path: &Path, share_delete: bool) -> io::Result<fs::Fil
         },
     };
 
-    let path = path
-        .as_os_str()
-        .encode_wide()
-        .chain(Some(0))
-        .collect::<Vec<_>>();
+    let path = windows_api_path(path);
     let mut sharing = FILE_SHARE_READ | FILE_SHARE_WRITE;
     if share_delete {
         sharing |= FILE_SHARE_DELETE;
@@ -420,16 +432,38 @@ fn directory_identity(directory: &fs::File) -> io::Result<DirectoryIdentity> {
 
 #[cfg(windows)]
 fn create_file_at(parent: &PinnedParent, name: &OsStr) -> io::Result<fs::File> {
+    use std::os::windows::io::FromRawHandle;
+    use windows_sys::Win32::{
+        Foundation::{GENERIC_READ, GENERIC_WRITE, INVALID_HANDLE_VALUE},
+        Storage::FileSystem::{
+            CreateFileW, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, FILE_FLAG_OPEN_REPARSE_POINT,
+            FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+        },
+    };
+
     parent.verify_location()?;
-    fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(parent.path.join(name))
+    let path = windows_api_path(&parent.path.join(name));
+    let handle = unsafe {
+        CreateFileW(
+            path.as_ptr(),
+            GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            std::ptr::null(),
+            CREATE_NEW,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(unsafe { fs::File::from_raw_handle(handle) })
+    }
 }
 
 #[cfg(windows)]
 fn open_file_at(parent: &PinnedParent, name: &OsStr) -> io::Result<fs::File> {
-    use std::os::windows::{ffi::OsStrExt, io::FromRawHandle};
+    use std::os::windows::io::FromRawHandle;
     use windows_sys::Win32::{
         Foundation::{GENERIC_READ, INVALID_HANDLE_VALUE},
         Storage::FileSystem::{
@@ -439,13 +473,7 @@ fn open_file_at(parent: &PinnedParent, name: &OsStr) -> io::Result<fs::File> {
     };
 
     parent.verify_location()?;
-    let path = parent
-        .path
-        .join(name)
-        .as_os_str()
-        .encode_wide()
-        .chain(Some(0))
-        .collect::<Vec<_>>();
+    let path = windows_api_path(&parent.path.join(name));
     let handle = unsafe {
         CreateFileW(
             path.as_ptr(),
@@ -466,17 +494,28 @@ fn open_file_at(parent: &PinnedParent, name: &OsStr) -> io::Result<fs::File> {
 
 #[cfg(windows)]
 fn child_exists_at(parent: &PinnedParent, name: &OsStr) -> io::Result<bool> {
+    use windows_sys::Win32::{
+        Foundation::{GetLastError, ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND},
+        Storage::FileSystem::{GetFileAttributesW, INVALID_FILE_ATTRIBUTES},
+    };
+
     parent.verify_location()?;
-    match fs::symlink_metadata(parent.path.join(name)) {
-        Ok(_) => Ok(true),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
-        Err(error) => Err(error),
+    let path = windows_api_path(&parent.path.join(name));
+    let attributes = unsafe { GetFileAttributesW(path.as_ptr()) };
+    if attributes != INVALID_FILE_ATTRIBUTES {
+        return Ok(true);
+    }
+    let error = unsafe { GetLastError() };
+    if matches!(error, ERROR_FILE_NOT_FOUND | ERROR_PATH_NOT_FOUND) {
+        Ok(false)
+    } else {
+        Err(io::Error::from_raw_os_error(error as i32))
     }
 }
 
 #[cfg(windows)]
 fn open_file_for_write_at(parent: &PinnedParent, name: &OsStr) -> io::Result<fs::File> {
-    use std::os::windows::{ffi::OsStrExt, io::FromRawHandle};
+    use std::os::windows::io::FromRawHandle;
     use windows_sys::Win32::{
         Foundation::{GENERIC_READ, GENERIC_WRITE, INVALID_HANDLE_VALUE},
         Storage::FileSystem::{
@@ -486,13 +525,7 @@ fn open_file_for_write_at(parent: &PinnedParent, name: &OsStr) -> io::Result<fs:
     };
 
     parent.verify_location()?;
-    let path = parent
-        .path
-        .join(name)
-        .as_os_str()
-        .encode_wide()
-        .chain(Some(0))
-        .collect::<Vec<_>>();
+    let path = windows_api_path(&parent.path.join(name));
     let handle = unsafe {
         CreateFileW(
             path.as_ptr(),
@@ -513,26 +546,13 @@ fn open_file_for_write_at(parent: &PinnedParent, name: &OsStr) -> io::Result<fs:
 
 #[cfg(windows)]
 fn replace_at(parent: &PinnedParent, source: &OsStr, destination: &OsStr) -> io::Result<()> {
-    use std::os::windows::ffi::OsStrExt;
     use windows_sys::Win32::Storage::FileSystem::{
         MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
     };
 
     parent.verify_location()?;
-    let source = parent
-        .path
-        .join(source)
-        .as_os_str()
-        .encode_wide()
-        .chain(Some(0))
-        .collect::<Vec<_>>();
-    let destination = parent
-        .path
-        .join(destination)
-        .as_os_str()
-        .encode_wide()
-        .chain(Some(0))
-        .collect::<Vec<_>>();
+    let source = windows_api_path(&parent.path.join(source));
+    let destination = windows_api_path(&parent.path.join(destination));
     let moved = unsafe {
         MoveFileExW(
             source.as_ptr(),
@@ -553,24 +573,11 @@ fn rename_noreplace_at(
     source: &OsStr,
     destination: &OsStr,
 ) -> io::Result<()> {
-    use std::os::windows::ffi::OsStrExt;
     use windows_sys::Win32::Storage::FileSystem::{MoveFileExW, MOVEFILE_WRITE_THROUGH};
 
     parent.verify_location()?;
-    let source = parent
-        .path
-        .join(source)
-        .as_os_str()
-        .encode_wide()
-        .chain(Some(0))
-        .collect::<Vec<_>>();
-    let destination = parent
-        .path
-        .join(destination)
-        .as_os_str()
-        .encode_wide()
-        .chain(Some(0))
-        .collect::<Vec<_>>();
+    let source = windows_api_path(&parent.path.join(source));
+    let destination = windows_api_path(&parent.path.join(destination));
     let moved = unsafe {
         MoveFileExW(
             source.as_ptr(),
@@ -587,16 +594,37 @@ fn rename_noreplace_at(
 
 #[cfg(windows)]
 fn remove_at(parent: &PinnedParent, name: &OsStr) -> io::Result<()> {
+    use windows_sys::Win32::Storage::FileSystem::DeleteFileW;
+
     parent.verify_location()?;
-    fs::remove_file(parent.path.join(name))
+    let path = windows_api_path(&parent.path.join(name));
+    if unsafe { DeleteFileW(path.as_ptr()) } == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(windows)]
-fn is_reparse_point(metadata: &fs::Metadata) -> bool {
-    use std::os::windows::fs::MetadataExt;
-    metadata.file_attributes()
-        & windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT
-        != 0
+fn windows_api_path(path: &Path) -> Vec<u16> {
+    use std::os::windows::ffi::OsStrExt;
+
+    let raw = path.as_os_str().encode_wide().collect::<Vec<_>>();
+    const BACKSLASH: u16 = b'\\' as u16;
+    const QUESTION: u16 = b'?' as u16;
+    if raw.starts_with(&[BACKSLASH, BACKSLASH, QUESTION, BACKSLASH]) {
+        return raw.into_iter().chain(Some(0)).collect();
+    }
+    let mut extended = Vec::with_capacity(raw.len() + 9);
+    if raw.starts_with(&[BACKSLASH, BACKSLASH]) {
+        extended.extend(r"\\?\UNC\".encode_utf16());
+        extended.extend_from_slice(&raw[2..]);
+    } else {
+        extended.extend(r"\\?\".encode_utf16());
+        extended.extend_from_slice(&raw);
+    }
+    extended.push(0);
+    extended
 }
 
 #[cfg(unix)]
@@ -803,9 +831,4 @@ fn unix_name(name: &OsStr) -> io::Result<std::ffi::CString> {
             "mutation target name contains NUL",
         )
     })
-}
-
-#[cfg(unix)]
-fn is_reparse_point(_metadata: &fs::Metadata) -> bool {
-    false
 }

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ReHome Desktop",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "identifier": "com.calebycj.rehome",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src-tauri/tests/restore_test.rs
+++ b/desktop/src-tauri/tests/restore_test.rs
@@ -524,6 +524,28 @@ fn user_rollback_restores_exact_pre_restore_hashes_and_tombstones() -> Result<()
 }
 
 #[test]
+fn rollback_recovers_applied_states_from_sharded_checkpoints() -> Result<(), Box<dyn Error>> {
+    let harness = RestoreHarness::new(DatabaseSchema::Compatible)?;
+    let before = snapshot_mutable_targets(&harness.plan)?;
+    let report = apply_restore(harness.plan.clone(), harness.options())?;
+    let journal_path = harness.journal_path(report.transaction_id);
+    let mut journal = harness.read_journal(report.transaction_id)?;
+    journal["status"] = Value::String("applying".into());
+    for operation in journal["operations"].as_array_mut().unwrap() {
+        operation["applied_hash"] = Value::Null;
+        operation["applied_state"] = Value::Null;
+        operation["applied_database_hash"] = Value::Null;
+    }
+    fs::write(&journal_path, serde_json::to_vec_pretty(&journal)?)?;
+
+    let rollback_report = rollback(report.transaction_id)?;
+
+    assert!(rollback_report.success);
+    assert_eq!(snapshot_mutable_targets(&harness.plan)?, before);
+    Ok(())
+}
+
+#[test]
 fn restore_requires_explicit_confirmation_that_current_work_is_saved() -> Result<(), Box<dyn Error>>
 {
     let harness = RestoreHarness::new(DatabaseSchema::Compatible)?;


### PR DESCRIPTION
## Summary
- retry Codex files that change while a package is being created
- speed up large restores by sharding mutation checkpoints and reusing one authenticated archive handle
- support Windows restore targets longer than the legacy MAX_PATH limit
- release as ReHome Desktop v0.1.14

## Verification
- frontend: 34 tests passed
- frontend production build passed
- Rust full test suite passed
- clippy with warnings denied passed
- real isolated Windows acceptance: 4,187 project files, 1 conversation, 4,190 restored files
