### PR TITLE
Support larger migration packages

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rehome-desktop",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rehome-desktop",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-process": "^2.3.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rehome-desktop",
   "private": true,
-  "version": "0.1.14",
+  "version": "0.1.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2886,7 +2886,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rehome-desktop"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rehome-desktop"
-version = "0.1.14"
+version = "0.1.15"
 description = "ReHome Desktop migration utility"
 authors = ["ReHome contributors"]
 edition = "2021"

--- a/desktop/src-tauri/src/core/legacy.rs
+++ b/desktop/src-tauri/src/core/legacy.rs
@@ -23,9 +23,12 @@ use uuid::Uuid;
 use zip::ZipArchive;
 
 const LEGACY_SCHEMA: u32 = 3;
-const MAX_ENTRIES: usize = 10_000;
-const MAX_ENTRY_BYTES: u64 = 256 * 1024 * 1024;
-const MAX_TOTAL_BYTES: u64 = 1024 * 1024 * 1024;
+const MAX_ENTRIES: usize = 100_000;
+const MAX_CONTROL_BYTES: u64 = 4 * 1024 * 1024;
+const MAX_METADATA_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_ENTRY_BYTES: u64 = 16 * 1024 * 1024 * 1024;
+const MAX_TOTAL_BYTES: u64 = 16 * 1024 * 1024 * 1024;
+const MAX_ARCHIVE_FILE_BYTES: u64 = 2 * MAX_TOTAL_BYTES;
 const THREAD_COLUMNS: &[&str] = &[
     "id",
     "cwd",
@@ -77,9 +80,7 @@ pub(crate) fn inspect_schema_v3(path: &Path) -> Result<Option<VerifiedPackage>, 
         .map_err(|error| invalid(format!("could not rewind package: {error}")))?;
     let mut archive = ZipArchive::new(file)
         .map_err(|error| invalid(format!("invalid ZIP container: {error}")))?;
-    if archive.len() > MAX_ENTRIES {
-        return Err(invalid("ZIP entry count exceeds the inspection limit"));
-    }
+    ensure_legacy_entry_count(archive.len())?;
 
     let manifest_candidates = (0..archive.len())
         .filter_map(|index| {
@@ -101,7 +102,8 @@ pub(crate) fn inspect_schema_v3(path: &Path) -> Result<Option<VerifiedPackage>, 
     let prefix = manifest_name
         .strip_suffix("MANIFEST.json")
         .unwrap_or_default();
-    let manifest_bytes = read_archive_entry(&mut archive, manifest_name)?;
+    let manifest_bytes =
+        read_archive_entry_limited(&mut archive, manifest_name, MAX_CONTROL_BYTES, "manifest")?;
     let manifest: LegacyManifest = serde_json::from_slice(&manifest_bytes)
         .map_err(|error| invalid(format!("legacy MANIFEST.json is invalid: {error}")))?;
     if manifest.package_schema_version != LEGACY_SCHEMA {
@@ -403,8 +405,13 @@ fn read_project_sources(
     let Some(file) = files.get("metadata/path_map.json") else {
         return Ok(Vec::new());
     };
-    let value: Value = serde_json::from_slice(&read_archive_entry(archive, &file.archive_name)?)
-        .map_err(|error| invalid(format!("legacy path_map.json is invalid: {error}")))?;
+    let value: Value = serde_json::from_slice(&read_archive_entry_limited(
+        archive,
+        &file.archive_name,
+        MAX_METADATA_BYTES,
+        "path map",
+    )?)
+    .map_err(|error| invalid(format!("legacy path_map.json is invalid: {error}")))?;
     Ok(value
         .get("projects")
         .and_then(Value::as_array)
@@ -437,7 +444,12 @@ fn build_session_index(
         .collect::<HashSet<_>>();
     let mut rows = BTreeMap::<Uuid, Value>::new();
     if let Some(file) = files.get("home/.codex/session_index.jsonl") {
-        let bytes = read_archive_entry(archive, &file.archive_name)?;
+        let bytes = read_archive_entry_limited(
+            archive,
+            &file.archive_name,
+            MAX_METADATA_BYTES,
+            "session index",
+        )?;
         for line in bytes.split(|byte| *byte == b'\n') {
             let Ok(value) = serde_json::from_slice::<Value>(line) else {
                 continue;
@@ -480,12 +492,17 @@ fn build_thread_metadata(
     let Some(file) = files.get("metadata/thread_index_export.json") else {
         return Ok(None);
     };
-    let value: Value = serde_json::from_slice(&read_archive_entry(archive, &file.archive_name)?)
-        .map_err(|error| {
-            invalid(format!(
-                "legacy thread_index_export.json is invalid: {error}"
-            ))
-        })?;
+    let value: Value = serde_json::from_slice(&read_archive_entry_limited(
+        archive,
+        &file.archive_name,
+        MAX_METADATA_BYTES,
+        "thread metadata",
+    )?)
+    .map_err(|error| {
+        invalid(format!(
+            "legacy thread_index_export.json is invalid: {error}"
+        ))
+    })?;
     let selected = conversations
         .iter()
         .map(|conversation| conversation.task_id.to_string())
@@ -572,7 +589,12 @@ fn verify_legacy_checksums(
     let checksum = files
         .get("SHA256SUMS.txt")
         .ok_or_else(|| invalid("legacy SHA256SUMS.txt is missing"))?;
-    let bytes = read_archive_entry(archive, &checksum.archive_name)?;
+    let bytes = read_archive_entry_limited(
+        archive,
+        &checksum.archive_name,
+        MAX_METADATA_BYTES,
+        "checksum manifest",
+    )?;
     if bytes.starts_with(&[0xef, 0xbb, 0xbf]) || bytes.contains(&b'\r') {
         return Err(RehomeError::new(
             ErrorCode::ChecksumMismatch,
@@ -646,20 +668,55 @@ fn normalize_zip_name(raw: &str, directory: bool) -> Result<String, RehomeError>
     normalize_entry(Path::new(candidate))
 }
 
+fn ensure_legacy_entry_count(count: usize) -> Result<(), RehomeError> {
+    if count > MAX_ENTRIES {
+        return Err(invalid(format!(
+            "legacy package contains {count} entries and exceeds the {MAX_ENTRIES} entry limit"
+        )));
+    }
+    Ok(())
+}
+
+fn ensure_legacy_archive_size(size: u64) -> Result<(), RehomeError> {
+    if size > MAX_ARCHIVE_FILE_BYTES {
+        return Err(invalid(format!(
+            "legacy package file is {size} bytes and exceeds the {MAX_ARCHIVE_FILE_BYTES} byte inspection limit"
+        )));
+    }
+    Ok(())
+}
+
 fn read_archive_entry(
     archive: &mut ZipArchive<fs::File>,
     name: &str,
 ) -> Result<Vec<u8>, RehomeError> {
-    let mut entry = archive
+    read_archive_entry_limited(archive, name, MAX_ENTRY_BYTES, "planning payload")
+}
+
+fn read_archive_entry_limited(
+    archive: &mut ZipArchive<fs::File>,
+    name: &str,
+    limit: u64,
+    kind: &str,
+) -> Result<Vec<u8>, RehomeError> {
+    let entry = archive
         .by_name(name)
         .map_err(|error| invalid(format!("could not read legacy ZIP entry {name}: {error}")))?;
-    if entry.is_dir() || entry.size() > MAX_ENTRY_BYTES {
-        return Err(invalid("legacy ZIP entry is not a supported file"));
+    if entry.is_dir() || entry.size() > limit {
+        return Err(invalid(format!(
+            "legacy ZIP {kind} exceeds the {limit} byte limit: {name}"
+        )));
     }
     let mut bytes = Vec::new();
     entry
+        .take(limit + 1)
         .read_to_end(&mut bytes)
         .map_err(|error| invalid(format!("could not read legacy ZIP entry: {error}")))?;
+    if bytes.len() as u64 > limit {
+        return Err(invalid(format!(
+            "legacy ZIP {kind} exceeds the {limit} byte limit: {name}"
+        )));
+    }
     Ok(bytes)
 }
 
@@ -667,9 +724,7 @@ fn hash_file(file: &mut fs::File) -> Result<String, RehomeError> {
     let metadata = file
         .metadata()
         .map_err(|error| invalid(format!("could not inspect package: {error}")))?;
-    if metadata.len() > 2 * MAX_TOTAL_BYTES {
-        return Err(invalid("package file exceeds the inspection limit"));
-    }
+    ensure_legacy_archive_size(metadata.len())?;
     hash_reader(file)
 }
 
@@ -690,4 +745,23 @@ fn hash_reader(reader: &mut impl Read) -> Result<String, RehomeError> {
 
 fn invalid(message: impl Into<String>) -> RehomeError {
     RehomeError::new(ErrorCode::PackageInvalid, message)
+}
+
+#[cfg(test)]
+mod limit_tests {
+    use super::*;
+
+    #[test]
+    fn accepts_legacy_packages_larger_than_the_old_two_gib_limit() {
+        ensure_legacy_archive_size(2 * 1024 * 1024 * 1024 + 128 * 1024 * 1024).unwrap();
+        ensure_legacy_archive_size(MAX_ARCHIVE_FILE_BYTES).unwrap();
+        ensure_legacy_archive_size(MAX_ARCHIVE_FILE_BYTES + 1).unwrap_err();
+    }
+
+    #[test]
+    fn accepts_large_legacy_project_entry_counts() {
+        ensure_legacy_entry_count(50_000).unwrap();
+        ensure_legacy_entry_count(MAX_ENTRIES).unwrap();
+        ensure_legacy_entry_count(MAX_ENTRIES + 1).unwrap_err();
+    }
 }

--- a/desktop/src-tauri/src/core/package.rs
+++ b/desktop/src-tauri/src/core/package.rs
@@ -30,7 +30,7 @@ use zip::{write::SimpleFileOptions, CompressionMethod, DateTime, ZipArchive, Zip
 
 const FORMAT: &str = "codex-rehome";
 const SCHEMA_VERSION: u32 = 1;
-const MAX_ARCHIVE_ENTRIES: usize = 10_000;
+const MAX_ARCHIVE_ENTRIES: usize = 100_000;
 const MAX_CONTROL_FILE_BYTES: u64 = 4 * 1024 * 1024;
 // Keep the planning limit aligned with the package's existing per-file and
 // total-size safety ceiling. This lets a large Codex conversation be checked
@@ -366,11 +366,7 @@ pub(crate) fn inspect_package_for_planning(path: &Path) -> Result<VerifiedPackag
         .map_err(|error| package_invalid(format!("could not rewind package: {error}")))?;
     let mut archive = ZipArchive::new(file)
         .map_err(|error| package_invalid(format!("invalid ZIP container: {error}")))?;
-    if archive.len() > MAX_ARCHIVE_ENTRIES {
-        return Err(package_invalid(
-            "ZIP entry count exceeds the inspection limit",
-        ));
-    }
+    ensure_archive_entry_count(archive.len())?;
 
     let mut names = Vec::with_capacity(archive.len());
     let mut paths = PortablePathRegistry::default();
@@ -1269,6 +1265,15 @@ fn format_package_bytes(bytes: u64) -> String {
     }
 }
 
+fn ensure_archive_entry_count(count: usize) -> Result<(), RehomeError> {
+    if count > MAX_ARCHIVE_ENTRIES {
+        return Err(package_invalid(format!(
+            "package contains {count} entries and exceeds the {MAX_ARCHIVE_ENTRIES} entry limit; deselect generated or dependency files and try again"
+        )));
+    }
+    Ok(())
+}
+
 fn checked_staged_total_bytes(current: u64, next: u64) -> Result<u64, RehomeError> {
     let total = current.checked_add(next).ok_or_else(|| {
         package_invalid(format!(
@@ -1335,11 +1340,7 @@ fn staged_archive_entries(
             return Err(package_invalid("staging contains a non-regular entry"));
         }
     }
-    if entries.len() > MAX_ARCHIVE_ENTRIES {
-        return Err(package_invalid(
-            "staged package entry count exceeds the limit",
-        ));
-    }
+    ensure_archive_entry_count(entries.len())?;
     entries.sort_by(|left, right| left.name.cmp(&right.name));
     Ok(entries)
 }
@@ -1565,6 +1566,13 @@ mod authenticated_payload_tests {
         let total = checked_staged_total_bytes(nine_gib, one_gib).unwrap();
 
         assert_eq!(total, 10_u64 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn package_entry_limit_accepts_large_real_projects() {
+        ensure_archive_entry_count(50_000).unwrap();
+        ensure_archive_entry_count(MAX_ARCHIVE_ENTRIES).unwrap();
+        ensure_archive_entry_count(MAX_ARCHIVE_ENTRIES + 1).unwrap_err();
     }
 
     #[test]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ReHome Desktop",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "identifier": "com.calebycj.rehome",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src-tauri/tests/package_test.rs
+++ b/desktop/src-tauri/tests/package_test.rs
@@ -607,7 +607,7 @@ fn rejects_invalid_or_missing_manifest_payload_references() -> Result<(), Box<dy
 }
 
 #[test]
-fn inspection_rejects_oversized_controls_and_entry_counts() -> Result<(), Box<dyn Error>> {
+fn inspection_rejects_oversized_controls() -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
 
     let oversized_control = directory.path().join("oversized-control.rehome");
@@ -617,9 +617,6 @@ fn inspection_rejects_oversized_controls_and_entry_counts() -> Result<(), Box<dy
     )?;
     assert_error_message_contains(inspect_package(&oversized_control), "control file size");
 
-    let excessive_count = directory.path().join("excessive-count.rehome");
-    write_many_directories_zip(&excessive_count, 10_001)?;
-    assert_error_message_contains(inspect_package(&excessive_count), "entry count");
     Ok(())
 }
 
@@ -1031,20 +1028,6 @@ fn write_valid_test_package(
     entries.push(("checksums.sha256", checksum_text.as_bytes()));
     entries.push(("manifest.json", &manifest));
     write_test_zip(path, &entries)
-}
-
-fn write_many_directories_zip(path: &Path, count: usize) -> Result<(), Box<dyn Error>> {
-    let file = fs::File::create(path)?;
-    let mut writer = ZipWriter::new(file);
-    let options = SimpleFileOptions::default()
-        .compression_method(CompressionMethod::Stored)
-        .last_modified_time(DateTime::default())
-        .unix_permissions(0o755);
-    for index in 0..count {
-        writer.add_directory(format!("entries/{index:05}/"), options)?;
-    }
-    writer.finish()?;
-    Ok(())
 }
 
 fn replace_all(path: &Path, from: &[u8], to: &[u8]) -> Result<usize, Box<dyn Error>> {


### PR DESCRIPTION
## Summary
- raise modern and legacy package entry limits from 10,000 to 100,000
- align legacy package inspection with the existing 16 GiB migration ceiling
- keep small control and metadata files under tighter limits
- release as ReHome Desktop v0.1.15

## Verification
- npm test -- --run (34 passed)
- npm run build
- cargo test (all passed)
- cargo clippy --all-targets -- -D warnings
- cargo fmt --check

Fixes #28
Fixes #30
Addresses #27 (packages up to 16 GiB; larger migrations should be split)