### PR TITLE
Support linked Codex data directories on Windows

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rehome-desktop",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rehome-desktop",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-process": "^2.3.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rehome-desktop",
   "private": true,
-  "version": "0.1.18",
+  "version": "0.1.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2886,7 +2886,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rehome-desktop"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rehome-desktop"
-version = "0.1.18"
+version = "0.1.19"
 description = "ReHome Desktop migration utility"
 authors = ["ReHome contributors"]
 edition = "2021"

--- a/desktop/src-tauri/src/core/discovery.rs
+++ b/desktop/src-tauri/src/core/discovery.rs
@@ -251,7 +251,7 @@ fn resolve_existing_codex_home(path: &Path) -> Result<(PathBuf, bool), RehomeErr
 
     #[cfg(not(windows))]
     {
-        return Err(codex_home_not_found());
+        Err(codex_home_not_found())
     }
 
     #[cfg(windows)]

--- a/desktop/src-tauri/src/core/discovery.rs
+++ b/desktop/src-tauri/src/core/discovery.rs
@@ -76,18 +76,16 @@ pub fn discover_codex_with_context(
     override_home: Option<PathBuf>,
     context: &DiscoveryContext,
 ) -> Result<CodexInventory, RehomeError> {
-    let codex_home = resolve_codex_home(override_home, context)?;
-    let codex_home_is_real_directory = fs::symlink_metadata(&codex_home)
-        .map(|metadata| metadata.is_dir() && !metadata.file_type().is_symlink())
-        .unwrap_or(false);
-    if !codex_home_is_real_directory {
-        return Err(RehomeError::new(
-            ErrorCode::CodexNotFound,
-            "Codex home does not exist, is not a directory, or is a symbolic link",
+    let requested_codex_home = resolve_codex_home(override_home, context)?;
+    let (codex_home, linked_home_resolved) = resolve_existing_codex_home(&requested_codex_home)?;
+    let mut warnings = Vec::new();
+    if linked_home_resolved {
+        warnings.push(format!(
+            "Codex home link was resolved from {} to {}",
+            requested_codex_home.display(),
+            codex_home.display()
         ));
     }
-
-    let mut warnings = Vec::new();
     let mut conversation_paths = collect_files(
         &codex_home.join("sessions"),
         |path| extension_is(path, "jsonl"),
@@ -243,6 +241,69 @@ pub fn discover_codex_with_context(
         generated_images,
         warnings,
     })
+}
+
+fn resolve_existing_codex_home(path: &Path) -> Result<(PathBuf, bool), RehomeError> {
+    let metadata = fs::symlink_metadata(path).map_err(|_| codex_home_not_found())?;
+    if metadata.is_dir() && !metadata.file_type().is_symlink() {
+        return Ok((path.to_path_buf(), false));
+    }
+
+    #[cfg(not(windows))]
+    {
+        return Err(codex_home_not_found());
+    }
+
+    #[cfg(windows)]
+    {
+        let canonical = fs::canonicalize(path).map_err(|_| codex_home_not_found())?;
+        let canonical = local_canonical_codex_home(canonical)?;
+        let target_metadata =
+            fs::symlink_metadata(&canonical).map_err(|_| codex_home_not_found())?;
+        if !target_metadata.is_dir() || target_metadata.file_type().is_symlink() {
+            return Err(codex_home_not_found());
+        }
+        Ok((canonical, true))
+    }
+}
+
+#[cfg(windows)]
+fn local_canonical_codex_home(path: PathBuf) -> Result<PathBuf, RehomeError> {
+    let raw = path.to_string_lossy();
+    if raw.starts_with(r"\\?\UNC\") {
+        return Err(RehomeError::new(
+            ErrorCode::CodexNotFound,
+            "Linked Codex home must resolve to a local disk",
+        ));
+    }
+    let Some(local) = raw.strip_prefix(r"\\?\") else {
+        if raw.starts_with(r"\\") {
+            return Err(RehomeError::new(
+                ErrorCode::CodexNotFound,
+                "Linked Codex home must resolve to a local disk",
+            ));
+        }
+        return Ok(path);
+    };
+    let bytes = local.as_bytes();
+    if bytes.len() < 3
+        || !bytes[0].is_ascii_alphabetic()
+        || bytes[1] != b':'
+        || !matches!(bytes[2], b'\\' | b'/')
+    {
+        return Err(RehomeError::new(
+            ErrorCode::CodexNotFound,
+            "Linked Codex home must resolve to a local disk",
+        ));
+    }
+    Ok(PathBuf::from(local))
+}
+
+fn codex_home_not_found() -> RehomeError {
+    RehomeError::new(
+        ErrorCode::CodexNotFound,
+        "Codex home does not exist or does not resolve to a directory",
+    )
 }
 
 fn discovered_projects(paths: &[PathBuf]) -> Vec<ProjectEntry> {

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ReHome Desktop",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "identifier": "com.calebycj.rehome",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src-tauri/tests/discovery_test.rs
+++ b/desktop/src-tauri/tests/discovery_test.rs
@@ -654,8 +654,9 @@ fn missing_or_non_directory_codex_home_has_stable_error_code() -> Result<(), Box
     Ok(())
 }
 
+#[cfg(windows)]
 #[test]
-fn symlinked_codex_home_is_rejected() -> Result<(), Box<dyn Error>> {
+fn symlinked_codex_home_resolves_to_its_real_directory() -> Result<(), Box<dyn Error>> {
     let temp = tempfile::tempdir()?;
     let real_home = temp.path().join("real-codex-home");
     let linked_home = temp.path().join("linked-codex-home");
@@ -667,6 +668,28 @@ fn symlinked_codex_home_is_rejected() -> Result<(), Box<dyn Error>> {
         }
         return Err(error.into());
     }
+
+    let inventory =
+        discover_codex_with_context(Some(linked_home.clone()), &DiscoveryContext::default())?;
+    assert_eq!(
+        fs::canonicalize(&inventory.codex_home)?,
+        fs::canonicalize(&real_home)?
+    );
+    assert!(inventory.warnings.iter().any(|warning| {
+        warning.contains("Codex home link was resolved")
+            && warning.contains(&linked_home.to_string_lossy().to_string())
+    }));
+    Ok(())
+}
+
+#[cfg(not(windows))]
+#[test]
+fn symlinked_codex_home_is_rejected() -> Result<(), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let real_home = temp.path().join("real-codex-home");
+    let linked_home = temp.path().join("linked-codex-home");
+    fs::create_dir(&real_home)?;
+    create_dir_symlink(&real_home, &linked_home)?;
 
     let error =
         discover_codex_with_context(Some(linked_home), &DiscoveryContext::default()).unwrap_err();
@@ -777,16 +800,43 @@ fn create_junction(target: &Path, link: &Path) -> std::io::Result<()> {
 
 #[cfg(windows)]
 #[test]
-fn junctioned_codex_home_is_rejected_without_symlink_privileges() -> Result<(), Box<dyn Error>> {
+fn junctioned_codex_home_resolves_without_symlink_privileges() -> Result<(), Box<dyn Error>> {
     let temp = tempfile::tempdir()?;
     let real_home = temp.path().join("real-codex-home");
     let junction_home = temp.path().join("junction-codex-home");
-    fs::create_dir(&real_home)?;
+    let task_id = Uuid::new_v4();
+    let sessions = real_home.join("sessions");
+    fs::create_dir_all(&sessions)?;
+    fs::write(
+        sessions.join(format!("{task_id}.jsonl")),
+        format!(
+            "{}\n",
+            json!({
+                "type": "session_meta",
+                "payload": {
+                    "id": task_id,
+                    "timestamp": "2026-08-31T10:00:00Z",
+                    "cwd": r"D:\Codex\Linked Project"
+                }
+            })
+        ),
+    )?;
     create_junction(&real_home, &junction_home)?;
 
-    let error =
-        discover_codex_with_context(Some(junction_home), &DiscoveryContext::default()).unwrap_err();
-    assert_eq!(error.code, ErrorCode::CodexNotFound);
+    let inventory =
+        discover_codex_with_context(Some(junction_home.clone()), &DiscoveryContext::default())?;
+    assert_eq!(
+        fs::canonicalize(&inventory.codex_home)?,
+        fs::canonicalize(&real_home)?
+    );
+    assert!(inventory.warnings.iter().any(|warning| {
+        warning.contains("Codex home link was resolved")
+            && warning.contains(&junction_home.to_string_lossy().to_string())
+    }));
+    assert_eq!(inventory.conversations.len(), 1);
+    assert_eq!(inventory.conversations[0].task_id, task_id);
+    assert!(fs::canonicalize(&inventory.conversation_paths[0])?
+        .starts_with(fs::canonicalize(&real_home)?));
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- resolve Windows .codex directory links and junctions to their real local-disk target before discovery
- keep UNC/network link targets rejected
- keep macOS linked Codex homes rejected and preserve project/source link exclusions
- add real Windows junction coverage that discovers a conversation through the linked path
- bump ReHome Desktop to v0.1.19

## Validation
- Windows symlink and junction tests: passed
- discovery tests: 27/27 passed
- Rust full suite: 220 passed, 2 real-profile tests ignored by default
- clippy with warnings denied: passed
- rustfmt and diff checks: passed
- frontend: 37/37 passed
- production frontend build: passed
- cargo check --locked: passed

## User report
Fixes ReHome showing Codex as undetected when C:\\Users\\<user>\\.codex is a junction or directory link to a local drive such as D:.