### PR TITLE
Allow packing with malformed optional session index rows

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rehome-desktop",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rehome-desktop",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-process": "^2.3.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rehome-desktop",
   "private": true,
-  "version": "0.1.19",
+  "version": "0.1.20",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2886,7 +2886,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rehome-desktop"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rehome-desktop"
-version = "0.1.19"
+version = "0.1.20"
 description = "ReHome Desktop migration utility"
 authors = ["ReHome contributors"]
 edition = "2021"

--- a/desktop/src-tauri/src/core/package.rs
+++ b/desktop/src-tauri/src/core/package.rs
@@ -887,8 +887,14 @@ fn read_selected_session_index_once(
         if line.trim().is_empty() {
             continue;
         }
-        let value: Value = serde_json::from_str(line)
-            .map_err(|_| package_invalid("session index contains malformed JSONL"))?;
+        // The index is optional metadata and Codex can leave stale or partial rows.
+        // Discovery already ignores those rows, so packing must remain equally tolerant.
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if !value.is_object() {
+            continue;
+        }
         let Some(id) = metadata_uuid(&value, &["id", "thread_id"]) else {
             continue;
         };

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ReHome Desktop",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "identifier": "com.calebycj.rehome",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src-tauri/tests/package_test.rs
+++ b/desktop/src-tauri/tests/package_test.rs
@@ -1054,6 +1054,30 @@ fn package_synthesizes_a_missing_selected_session_index_row() -> Result<(), Box<
 }
 
 #[test]
+fn package_skips_malformed_optional_session_index_rows() -> Result<(), Box<dyn Error>> {
+    let fixture = synthetic_codex_fixture()?;
+    let valid_row = fs::read_to_string(&fixture.session_index_path)?;
+    fs::write(
+        &fixture.session_index_path,
+        format!("not-json\n{valid_row}[]\n"),
+    )?;
+    let directory = tempfile::tempdir()?;
+    let package = directory.path().join("malformed-index.rehome");
+
+    create_package(package_request(&fixture, package.clone()))?;
+
+    let index = String::from_utf8(read_zip_entry(&package, "codex/session_index.jsonl")?)?;
+    let rows = index
+        .lines()
+        .map(serde_json::from_str)
+        .collect::<Result<Vec<Value>, _>>()?;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["id"], THREAD_ID);
+    assert_eq!(rows[0]["thread_name"], "Synthetic migration thread");
+    Ok(())
+}
+
+#[test]
 fn symbolic_links_in_selected_projects_are_safely_excluded() -> Result<(), Box<dyn Error>> {
     let fixture = synthetic_codex_fixture()?;
     let outside = fixture.root.join("outside-secret.txt");


### PR DESCRIPTION
## Summary

- skip malformed/non-object rows in the optional Codex session index during packing
- preserve all valid selected metadata rows and synthesize missing selected rows from the rollout/database
- add a regression test and bump ReHome Desktop to v0.1.20

## Verification

- cargo test: 221 passed, 2 ignored local-profile acceptance tests
- cargo clippy --all-targets -- -D warnings
- cargo fmt -- --check
- npm test: 37 passed
- npm run build