### PR TITLE
Fix multi-rollout imports and large checksum manifests

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rehome-desktop",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rehome-desktop",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-process": "^2.3.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rehome-desktop",
   "private": true,
-  "version": "0.1.20",
+  "version": "0.1.21",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2886,7 +2886,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rehome-desktop"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rehome-desktop"
-version = "0.1.20"
+version = "0.1.21"
 description = "ReHome Desktop migration utility"
 authors = ["ReHome contributors"]
 edition = "2021"

--- a/desktop/src-tauri/src/core/discovery.rs
+++ b/desktop/src-tauri/src/core/discovery.rs
@@ -151,7 +151,7 @@ pub fn discover_codex_with_context(
         &mut warnings,
     );
 
-    let sqlite_threads = state_db_path
+    let (sqlite_threads, active_rollout_paths) = state_db_path
         .as_deref()
         .map(|path| {
             read_state_database_roots(
@@ -164,7 +164,7 @@ pub fn discover_codex_with_context(
                 &mut warnings,
             )
         })
-        .unwrap_or(0);
+        .unwrap_or_else(|| (0, BTreeMap::new()));
 
     let projects = discovered_projects(&project_paths);
     let conversations = discovered_conversations(
@@ -172,6 +172,7 @@ pub fn discover_codex_with_context(
         &conversation_paths,
         session_index_path.as_deref(),
         &projects,
+        &active_rollout_paths,
         &mut warnings,
     );
 
@@ -336,6 +337,7 @@ fn discovered_conversations(
     paths: &[PathBuf],
     session_index_path: Option<&Path>,
     projects: &[ProjectEntry],
+    active_rollout_paths: &BTreeMap<Uuid, PathBuf>,
     warnings: &mut Vec<String>,
 ) -> Vec<ConversationEntry> {
     let index = read_session_index_entries(session_index_path, warnings);
@@ -405,8 +407,66 @@ fn discovered_conversations(
             classification,
         });
     }
-    conversations.sort_by_key(|conversation| conversation.task_id);
-    conversations
+    let mut grouped = BTreeMap::<Uuid, Vec<ConversationEntry>>::new();
+    for conversation in conversations {
+        grouped
+            .entry(conversation.task_id)
+            .or_default()
+            .push(conversation);
+    }
+    let mut selected = Vec::new();
+    for (task_id, mut candidates) in grouped {
+        if candidates.len() == 1 {
+            selected.push(candidates.pop().expect("single conversation candidate"));
+            continue;
+        }
+        let matching = active_rollout_paths
+            .get(&task_id)
+            .map(|active| {
+                candidates
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(index, candidate)| {
+                        discovered_rollout_matches(codex_home, candidate, active).then_some(index)
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        if matching.len() == 1 {
+            selected.push(candidates.swap_remove(matching[0]));
+            continue;
+        }
+        push_warning_unique(
+            warnings,
+            format!(
+                "Conversation {task_id} has multiple rollout files but no unique active SQLite rollout_path"
+            ),
+        );
+        selected.extend(candidates);
+    }
+    selected.sort_by_key(|conversation| conversation.task_id);
+    selected
+}
+
+fn discovered_rollout_matches(
+    codex_home: &Path,
+    conversation: &ConversationEntry,
+    active: &Path,
+) -> bool {
+    let Some(relative) = conversation.archive_path.strip_prefix("codex/") else {
+        return false;
+    };
+    let candidate = codex_home.join(Path::new(relative));
+    let active = if active.is_absolute() {
+        active.to_path_buf()
+    } else {
+        codex_home.join(active)
+    };
+    candidate == active
+        || match (candidate.canonicalize(), active.canonicalize()) {
+            (Ok(candidate), Ok(active)) => candidate == active,
+            _ => false,
+        }
 }
 
 fn read_session_metadata_file(path: &Path) -> io::Result<Option<SessionMetadata>> {
@@ -791,14 +851,14 @@ fn read_state_database_roots(
     path: &Path,
     mut fallback_projects: Option<(&mut Vec<PathBuf>, &mut HashSet<ProjectPathKey>)>,
     warnings: &mut Vec<String>,
-) -> u64 {
+) -> (u64, BTreeMap<Uuid, PathBuf>) {
     let snapshot = match StateDatabaseSnapshot::create(path) {
         Ok(snapshot) => snapshot,
         Err(error) => {
             warnings.push(format!(
                 "Could not snapshot the newest Codex state database: {error}"
             ));
-            return 0;
+            return (0, BTreeMap::new());
         }
     };
     let flags = OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX;
@@ -806,7 +866,7 @@ fn read_state_database_roots(
         Ok(connection) => connection,
         Err(_) => {
             warnings.push("Could not open the newest Codex state database read-only".to_owned());
-            return 0;
+            return (0, BTreeMap::new());
         }
     };
 
@@ -814,9 +874,11 @@ fn read_state_database_roots(
         Ok(count) => count,
         Err(_) => {
             warnings.push("Could not count threads in the newest Codex state database".to_owned());
-            return 0;
+            return (0, BTreeMap::new());
         }
     };
+
+    let active_rollout_paths = read_active_rollout_paths(&connection, warnings);
 
     let mut statement = match connection.prepare("SELECT cwd FROM threads ORDER BY rowid") {
         Ok(statement) => statement,
@@ -824,7 +886,7 @@ fn read_state_database_roots(
             warnings.push(
                 "Could not read project roots from the newest Codex state database".to_owned(),
             );
-            return count;
+            return (count, active_rollout_paths);
         }
     };
     let rows = match statement.query_map([], |row| row.get::<_, Option<String>>(0)) {
@@ -833,7 +895,7 @@ fn read_state_database_roots(
             warnings.push(
                 "Could not read project roots from the newest Codex state database".to_owned(),
             );
-            return count;
+            return (count, active_rollout_paths);
         }
     };
     for row in rows {
@@ -847,7 +909,52 @@ fn read_state_database_roots(
             Err(_) => warnings.push("Ignored an unreadable thread project root".to_owned()),
         }
     }
-    count
+    (count, active_rollout_paths)
+}
+
+fn read_active_rollout_paths(
+    connection: &Connection,
+    warnings: &mut Vec<String>,
+) -> BTreeMap<Uuid, PathBuf> {
+    let mut statement =
+        match connection.prepare("SELECT id, rollout_path FROM threads ORDER BY rowid") {
+            Ok(statement) => statement,
+            Err(_) => {
+                warnings.push(
+                    "Could not read active rollout paths from the newest Codex state database"
+                        .to_owned(),
+                );
+                return BTreeMap::new();
+            }
+        };
+    let rows = match statement.query_map([], |row| {
+        Ok((
+            row.get::<_, Option<String>>(0)?,
+            row.get::<_, Option<String>>(1)?,
+        ))
+    }) {
+        Ok(rows) => rows,
+        Err(_) => {
+            warnings.push(
+                "Could not read active rollout paths from the newest Codex state database"
+                    .to_owned(),
+            );
+            return BTreeMap::new();
+        }
+    };
+    let mut paths = BTreeMap::new();
+    for row in rows {
+        match row {
+            Ok((Some(id), Some(path))) if !path.is_empty() => {
+                if let Ok(id) = Uuid::parse_str(&id) {
+                    paths.insert(id, PathBuf::from(path));
+                }
+            }
+            Ok(_) => {}
+            Err(_) => warnings.push("Ignored an unreadable active rollout path".to_owned()),
+        }
+    }
+    paths
 }
 
 fn push_unique_path(raw: &str, projects: &mut Vec<PathBuf>, seen: &mut HashSet<ProjectPathKey>) {

--- a/desktop/src-tauri/src/core/package.rs
+++ b/desktop/src-tauri/src/core/package.rs
@@ -32,6 +32,7 @@ const FORMAT: &str = "codex-rehome";
 const SCHEMA_VERSION: u32 = 1;
 const MAX_ARCHIVE_ENTRIES: usize = 100_000;
 const MAX_CONTROL_FILE_BYTES: u64 = 4 * 1024 * 1024;
+const MAX_CHECKSUM_FILE_BYTES: u64 = 64 * 1024 * 1024;
 // Keep the planning limit aligned with the package's existing per-file and
 // total-size safety ceiling. This lets a large Codex conversation be checked
 // and path-rewritten instead of being rejected by a smaller legacy limit.
@@ -1630,7 +1631,7 @@ fn validate_manifest_archive_path(path: &str) -> Result<String, RehomeError> {
 fn read_control_entry<R: Read>(reader: &mut R, name: &str) -> Result<Vec<u8>, RehomeError> {
     let mut bytes = Vec::new();
     reader
-        .take(MAX_CONTROL_FILE_BYTES + 1)
+        .take(control_file_limit(name) + 1)
         .read_to_end(&mut bytes)
         .map_err(|error| package_invalid(format!("could not read ZIP control file: {error}")))?;
     ensure_control_size(name, bytes.len() as u64)?;
@@ -1716,6 +1717,23 @@ mod authenticated_payload_tests {
     }
 
     #[test]
+    fn checksum_control_file_accepts_more_than_the_legacy_limit() {
+        ensure_control_size("checksums.sha256", MAX_CONTROL_FILE_BYTES + 1).unwrap();
+        ensure_control_size("checksums.sha256", MAX_CHECKSUM_FILE_BYTES).unwrap();
+        ensure_control_size("checksums.sha256", MAX_CHECKSUM_FILE_BYTES + 1).unwrap_err();
+        ensure_control_size("manifest.json", MAX_CONTROL_FILE_BYTES + 1).unwrap_err();
+
+        let bytes = vec![b'x'; (MAX_CONTROL_FILE_BYTES + 1) as usize];
+        let mut reader = bytes.as_slice();
+        assert_eq!(
+            read_control_entry(&mut reader, "checksums.sha256")
+                .unwrap()
+                .len(),
+            bytes.len()
+        );
+    }
+
+    #[test]
     fn staged_total_size_error_reports_the_actual_size_and_limit() {
         let actual = MAX_INSPECTION_BYTES + 1;
 
@@ -1779,12 +1797,20 @@ fn hash_archive_file(file: &mut fs::File) -> Result<String, RehomeError> {
 }
 
 fn ensure_control_size(name: &str, size: u64) -> Result<(), RehomeError> {
-    if size > MAX_CONTROL_FILE_BYTES {
+    if size > control_file_limit(name) {
         return Err(package_invalid(format!(
             "ZIP control file size exceeds the inspection limit: {name}"
         )));
     }
     Ok(())
+}
+
+fn control_file_limit(name: &str) -> u64 {
+    if name == "checksums.sha256" {
+        MAX_CHECKSUM_FILE_BYTES
+    } else {
+        MAX_CONTROL_FILE_BYTES
+    }
 }
 
 fn ensure_planning_payload_size(name: &str, size: u64) -> Result<(), RehomeError> {

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ReHome Desktop",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "identifier": "com.calebycj.rehome",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src-tauri/tests/discovery_test.rs
+++ b/desktop/src-tauri/tests/discovery_test.rs
@@ -503,6 +503,47 @@ fn discovery_reports_fixture_without_modifying_it() -> Result<(), Box<dyn Error>
 }
 
 #[test]
+fn discovery_uses_sqlite_active_rollout_for_duplicate_thread_files() -> Result<(), Box<dyn Error>> {
+    let fixture = synthetic_codex_fixture()?;
+    let older_rollout = fixture
+        .session_path
+        .parent()
+        .ok_or("session has no parent")?
+        .join(format!("rollout-2026-07-21T00-00-00-{THREAD_ID}.jsonl"));
+    fs::copy(&fixture.session_path, &older_rollout)?;
+    let connection = Connection::open(&fixture.state_db_path)?;
+    connection.execute(
+        "UPDATE threads SET rollout_path = ?1 WHERE id = ?2",
+        params![fixture.session_path.to_string_lossy().as_ref(), THREAD_ID],
+    )?;
+    drop(connection);
+
+    let inventory = discover_codex_with_context(
+        Some(fixture.codex_home.clone()),
+        &DiscoveryContext::default(),
+    )?;
+
+    assert_eq!(inventory.conversation_paths.len(), 2);
+    assert_eq!(inventory.conversations.len(), 1);
+    assert_eq!(
+        inventory.conversations[0].task_id,
+        Uuid::parse_str(THREAD_ID)?
+    );
+    assert_eq!(
+        inventory.conversations[0].archive_path,
+        format!(
+            "codex/{}",
+            fixture
+                .session_path
+                .strip_prefix(&fixture.codex_home)?
+                .to_string_lossy()
+                .replace('\\', "/")
+        )
+    );
+    Ok(())
+}
+
+#[test]
 fn discovery_combines_global_state_and_sqlite_roots_in_stable_order() -> Result<(), Box<dyn Error>>
 {
     let fixture = synthetic_codex_fixture()?;

--- a/desktop/src/App.test.tsx
+++ b/desktop/src/App.test.tsx
@@ -688,6 +688,38 @@ describe("ReHome Desktop workflows", () => {
     expect(screen.getByText("冲突 0")).toBeVisible();
   });
 
+  it("puts blocking conflicts first and labels unresolved structural conflicts", async () => {
+    const user = userEvent.setup();
+    const conflictPlan = {
+      ...basePlan,
+      conflict_count: 1,
+      operations: [
+        basePlan.operations[0],
+        {
+          ...basePlan.operations[0],
+          package_source: "projects/project/files/blocked.txt",
+          target: "C:\\Restored Projects\\project\\blocked.txt",
+          action: "conflict",
+          expected_previous_hash: null,
+        },
+      ],
+    };
+    api.buildRestorePlan.mockResolvedValue(conflictPlan);
+    render(<App />);
+    await screen.findByText(inventory.codex_home);
+
+    await openReceive(user);
+
+    const rows = within(screen.getByRole("table")).getAllByRole("row");
+    expect(rows[1]).toHaveTextContent("projects/project/files/blocked.txt");
+    expect(rows[2]).toHaveTextContent("projects/rehome-app/README.md");
+
+    await user.click(screen.getByRole("button", { name: "保留新电脑文件（推荐）" }));
+
+    expect(await screen.findByText("结构冲突")).toBeVisible();
+    expect(screen.getByRole("button", { name: "导入到 Codex" })).toBeDisabled();
+  });
+
   it("offers the same conflict choices in English", async () => {
     const user = userEvent.setup();
     api.buildRestorePlan.mockResolvedValue({

--- a/desktop/src/features/receive/ReceivePage.tsx
+++ b/desktop/src/features/receive/ReceivePage.tsx
@@ -197,6 +197,11 @@ export default function ReceivePage({
   const canRestore = Boolean(
     plan && plan.conflict_count === 0 && codexClosed && phase === "idle" && !report,
   );
+  const planOperations = plan
+    ? [...plan.operations].sort(
+        (left, right) => Number(right.action === "conflict") - Number(left.action === "conflict"),
+      )
+    : [];
   const manualRegistration = report?.registrations.some(
     (registration) => !registrationIsComplete(registration.status),
   );
@@ -254,7 +259,7 @@ export default function ReceivePage({
           <div className="table-wrap">
             <table className="conflict-table">
               <thead><tr><th>{t("包内来源")}</th><th>{t("目标位置")}</th><th>{t("变更")}</th></tr></thead>
-              <tbody>{plan.operations.map((operation) => <tr key={`${operation.package_source}-${operation.target}`}><td><code>{operation.package_source}</code></td><td><code>{operation.target}</code></td><td><span className={`change change-${operation.action}`}>{changeLabel(operation.action, t)}</span></td></tr>)}</tbody>
+              <tbody>{planOperations.map((operation) => <tr key={`${operation.package_source}-${operation.target}`}><td><code>{operation.package_source}</code></td><td><code>{operation.target}</code></td><td><span className={`change change-${operation.action}`}>{changeLabel(operation.action, t, conflictResolution !== null)}</span></td></tr>)}</tbody>
             </table>
           </div>
           {plan.conflict_count > 0 && (
@@ -364,7 +369,12 @@ function sourceOsLabel(os: "windows" | "macos"): string {
   return os === "macos" ? "macOS" : "Windows";
 }
 
-function changeLabel(change: RestorePlan["operations"][number]["action"], t: (key: string) => string): string {
+function changeLabel(
+  change: RestorePlan["operations"][number]["action"],
+  t: (key: string) => string,
+  structuralConflict: boolean,
+): string {
+  if (change === "conflict" && structuralConflict) return t("结构冲突");
   return t({ add: "新增", update: "更新", unchanged: "不变", preserve: "保留本机", conflict: "冲突" }[change]);
 }
 

--- a/desktop/src/lib/i18n.tsx
+++ b/desktop/src/lib/i18n.tsx
@@ -124,6 +124,7 @@ const english: Record<string, string> = {
   "冲突 {count}": "Conflicts {count}",
   "发现 {count} 个同名但内容不同的文件。": "Same-name files with different content: {count}.",
   "仍有 {count} 个无法自动处理的结构冲突。": "{count} structural conflicts still require manual action.",
+  "结构冲突": "Structural conflict",
   "请选择如何处理这些普通文件冲突。": "Choose how ReHome should handle these regular file conflicts.",
   "请查看上表中的冲突路径，移开对应文件或目录，或重新选择一个空的项目保存位置后再预览。": "Review the conflict paths above, move the matching file or folder aside, or choose an empty project location and preview again.",
   "冲突处理方式": "Conflict resolution",


### PR DESCRIPTION
## Summary

- use Codex SQLite rollout_path to select the active target rollout without deleting immutable history files
- allow checksums.sha256 up to 64 MB during both package creation and inspection while retaining the 4 MB manifest limit
- surface blocking conflicts first and label unresolved items as structural conflicts
- bump ReHome Desktop to v0.1.21

Closes #42
Closes #43

## Verification

- cargo test --locked: 223 passed, 2 ignored local-profile acceptance tests
- cargo clippy --locked --all-targets -- -D warnings
- cargo fmt -- --check
- npm test: 38 passed
- npm run build
- updater manifest tests: 2 passed