### PR TITLE
fix: detect macOS ChatGPT app for project registration

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rehome-desktop",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rehome-desktop",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-process": "^2.3.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rehome-desktop",
   "private": true,
-  "version": "0.1.22",
+  "version": "0.1.23",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2886,7 +2886,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rehome-desktop"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rehome-desktop"
-version = "0.1.22"
+version = "0.1.23"
 description = "ReHome Desktop migration utility"
 authors = ["ReHome contributors"]
 edition = "2021"

--- a/desktop/src-tauri/src/core/bridge.rs
+++ b/desktop/src-tauri/src/core/bridge.rs
@@ -137,7 +137,9 @@ pub fn register_project(
         Ok(()) => RegistrationStatus::Registered,
         Err(CommandRunError::Unavailable) => RegistrationStatus::CommandUnavailable,
         Err(CommandRunError::InvocationFailed { message }) => {
-            RegistrationStatus::InvocationFailed { message }
+            RegistrationStatus::InvocationFailed {
+                message: format!("{} app: {message}", command.display()),
+            }
         }
     }
 }
@@ -146,18 +148,104 @@ pub fn register_project_with_detected_cli(
     target_os: SourceOs,
     project: &Path,
 ) -> RegistrationStatus {
-    let command = detect_registration_cli(target_os);
-    register_project(target_os, command.as_deref(), project, &SystemCommandRunner)
+    let candidates = registration_cli_candidates(target_os);
+    let command = candidates.iter().find(|candidate| candidate.is_file());
+    if command.is_none() && target_os == SourceOs::Macos {
+        return RegistrationStatus::InvocationFailed {
+            message: format!(
+                "Codex CLI not found. Checked: {}",
+                candidates
+                    .iter()
+                    .map(|path| path.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        };
+    }
+    register_project(
+        target_os,
+        command.map(PathBuf::as_path),
+        project,
+        &SystemCommandRunner,
+    )
 }
 
 pub fn detect_registration_cli(target_os: SourceOs) -> Option<PathBuf> {
-    let candidates = match target_os {
-        SourceOs::Macos => vec![PathBuf::from(
-            "/Applications/Codex.app/Contents/Resources/codex",
-        )],
+    registration_cli_candidates(target_os)
+        .into_iter()
+        .find(|candidate| candidate.is_file())
+}
+
+fn registration_cli_candidates(target_os: SourceOs) -> Vec<PathBuf> {
+    match target_os {
+        SourceOs::Macos => {
+            let mut roots = vec![];
+            if let Some(home) = env::var_os("HOME") {
+                let home = PathBuf::from(home);
+                if home.is_absolute() {
+                    roots.push(home.join("Applications"));
+                }
+            }
+            roots.push(PathBuf::from("/Applications"));
+            macos_cli_candidates(&roots, &running_macos_executables())
+        }
         SourceOs::Windows => windows_cli_candidates(),
+    }
+}
+
+fn macos_cli_candidates(application_dirs: &[PathBuf], running_exes: &[PathBuf]) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    for exe in running_exes {
+        let Some(macos) = exe.parent().filter(|path| path.ends_with("MacOS")) else {
+            continue;
+        };
+        let Some(contents) = macos.parent().filter(|path| path.ends_with("Contents")) else {
+            continue;
+        };
+        let Some(bundle) = contents.parent() else {
+            continue;
+        };
+        if bundle.ends_with("ChatGPT.app") || bundle.ends_with("Codex.app") {
+            candidates.push(contents.join("Resources/codex"));
+        }
+    }
+    for root in application_dirs {
+        for app in ["ChatGPT.app", "Codex.app"] {
+            candidates.push(root.join(app).join("Contents/Resources/codex"));
+        }
+    }
+    let mut seen = HashSet::new();
+    candidates.retain(|path| seen.insert(path.clone()));
+    candidates
+}
+
+#[cfg(target_os = "macos")]
+fn running_macos_executables() -> Vec<PathBuf> {
+    // Inspect only this user's processes. `comm` omits command-line arguments;
+    // wide output avoids truncating application paths. Never use a shell.
+    let Ok(output) = Command::new("/bin/ps")
+        .args(["-xww", "-o", "comm="])
+        .output()
+    else {
+        return vec![];
     };
-    candidates.into_iter().find(|candidate| candidate.is_file())
+    if !output.status.success() {
+        return vec![];
+    }
+    let mut paths: Vec<_> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .collect();
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+#[cfg(not(target_os = "macos"))]
+fn running_macos_executables() -> Vec<PathBuf> {
+    vec![]
 }
 
 fn windows_cli_candidates() -> Vec<PathBuf> {
@@ -1322,4 +1410,48 @@ fn package_invalid(message: impl Into<String>) -> RehomeError {
 
 fn restore_failed(message: impl Into<String>) -> RehomeError {
     RehomeError::new(ErrorCode::RestoreFailed, message)
+}
+
+#[cfg(test)]
+mod registration_discovery_tests {
+    use super::*;
+
+    #[test]
+    fn macos_supports_chatgpt_and_codex_in_system_and_user_applications() {
+        let candidates = macos_cli_candidates(
+            &[
+                PathBuf::from("/Applications"),
+                PathBuf::from("/Users/test/Applications"),
+            ],
+            &[],
+        );
+        for root in ["/Applications", "/Users/test/Applications"] {
+            for app in ["ChatGPT.app", "Codex.app"] {
+                assert!(candidates
+                    .contains(&Path::new(root).join(app).join("Contents/Resources/codex")));
+            }
+        }
+    }
+
+    #[test]
+    fn macos_prefers_running_app_and_ignores_unrelated_bundles() {
+        let active = PathBuf::from("/Volumes/Test Apps/ChatGPT.app/Contents/MacOS/ChatGPT");
+        let candidates = macos_cli_candidates(
+            &[PathBuf::from("/Applications")],
+            &[
+                active.clone(),
+                active,
+                PathBuf::from("/Applications/Other.app/Contents/MacOS/Other"),
+            ],
+        );
+        let expected = PathBuf::from("/Volumes/Test Apps/ChatGPT.app/Contents/Resources/codex");
+        assert_eq!(candidates.first(), Some(&expected));
+        assert_eq!(
+            candidates.iter().filter(|path| **path == expected).count(),
+            1
+        );
+        assert!(!candidates
+            .iter()
+            .any(|path| path.to_string_lossy().contains("Other.app")));
+    }
 }

--- a/desktop/src-tauri/src/core/models.rs
+++ b/desktop/src-tauri/src/core/models.rs
@@ -275,6 +275,7 @@ pub struct VerificationReport {
     pub forbidden_files_absent: bool,
     pub project_files_valid: bool,
     pub app_registration_valid: bool,
+    /// True only after application-level visibility verification, not registration.
     pub app_visible_ready: bool,
 }
 

--- a/desktop/src-tauri/src/core/restore.rs
+++ b/desktop/src-tauri/src/core/restore.rs
@@ -172,11 +172,13 @@ fn apply_transaction(
     update_status(transaction, RecoveryStatus::Committed)?;
     let registrations = register_projects(plan, options, verified, registrar);
     verification.app_registration_valid = options.register_projects
+        && !registrations.is_empty()
         && registrations
             .iter()
             .all(|result| result.status == RegistrationStatus::Registered);
-    verification.app_visible_ready =
-        data_verification_passed(&verification) && verification.app_registration_valid;
+    // Opening a project does not verify that Codex lists or can resume its
+    // conversations. Keep this unverified until an application-level check exists.
+    verification.app_visible_ready = false;
 
     Ok(RestoreReport {
         transaction_id: transaction.journal.transaction_id,

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ReHome Desktop",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "identifier": "com.calebycj.rehome",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src-tauri/tests/bridge_test.rs
+++ b/desktop/src-tauri/tests/bridge_test.rs
@@ -788,7 +788,7 @@ fn project_registration_reports_every_outcome_without_launching_codex() -> Resul
     assert_eq!(
         register_project(SourceOs::Macos, Some(cli), project, &failed),
         RegistrationStatus::InvocationFailed {
-            message: "exit code 7".into()
+            message: format!("{} app: exit code 7", cli.display())
         }
     );
     Ok(())

--- a/desktop/src-tauri/tests/restore_test.rs
+++ b/desktop/src-tauri/tests/restore_test.rs
@@ -1416,7 +1416,8 @@ fn apply_rejects_a_hardlink_added_after_planning() -> Result<(), Box<dyn Error>>
 }
 
 #[test]
-fn registration_runs_after_commit_and_sets_app_visible_ready() -> Result<(), Box<dyn Error>> {
+fn registration_runs_after_commit_but_does_not_prove_conversation_visibility(
+) -> Result<(), Box<dyn Error>> {
     let harness = RestoreHarness::new(DatabaseSchema::Compatible)?;
     let mut options = harness.options();
     options.register_projects = true;
@@ -1441,7 +1442,7 @@ fn registration_runs_after_commit_and_sets_app_visible_ready() -> Result<(), Box
         RegistrationStatus::Registered
     );
     assert!(report.verification.app_registration_valid);
-    assert!(report.verification.app_visible_ready);
+    assert!(!report.verification.app_visible_ready);
     Ok(())
 }
 

--- a/desktop/src/App.test.tsx
+++ b/desktop/src/App.test.tsx
@@ -891,6 +891,22 @@ describe("ReHome Desktop workflows", () => {
     expect(api.applyRestore).toHaveBeenLastCalledWith("fresh-plan", expect.any(Object));
   });
 
+  it("keeps conversation visibility unverified after successful project registration", async () => {
+    const user = userEvent.setup();
+    const report = restoreReportWithRegistration("registered");
+    report.verification.app_registration_valid = true;
+    report.verification.app_visible_ready = false;
+    api.applyRestore.mockResolvedValue(report);
+    render(<App />);
+    await screen.findByText(inventory.codex_home);
+    await openReceive(user);
+    await user.click(screen.getByRole("checkbox", { name: "确认已保存当前 Codex 工作" }));
+    await user.click(screen.getByRole("button", { name: "导入到 Codex" }));
+    expect(await screen.findByText("对话可见性待确认")).toBeInTheDocument();
+    expect(screen.getByText("文件和索引已导入。请重启 Codex，打开原对话并继续发送一条消息，确认可以使用。")).toBeInTheDocument();
+    expect(screen.queryByText("项目文件已导入，需要在 Codex 中手动打开")).toBeNull();
+  });
+
   it("uses the exact manual-open status when registration is incomplete", async () => {
     const user = userEvent.setup();
     api.applyRestore.mockResolvedValue({

--- a/desktop/src/App.test.tsx
+++ b/desktop/src/App.test.tsx
@@ -964,6 +964,19 @@ describe("ReHome Desktop workflows", () => {
     expect(await screen.findByText("Codex 命令调用失败")).toBeInTheDocument();
   });
 
+  it("shows the initial registration command failure without requiring another click", async () => {
+    const user = userEvent.setup();
+    const message = "/Applications/ChatGPT.app/Contents/Resources/codex app: exit code 7";
+    api.applyRestore.mockResolvedValue(restoreReportWithRegistration({ invocation_failed: { message } }));
+    render(<App />);
+    await screen.findByText(inventory.codex_home);
+    await openReceive(user);
+    await user.click(screen.getByRole("checkbox", { name: "确认已保存当前 Codex 工作" }));
+    await user.click(screen.getByRole("button", { name: "导入到 Codex" }));
+    expect(await screen.findByText(message)).toBeInTheDocument();
+    expect(api.openRestoredThread).not.toHaveBeenCalled();
+  });
+
   it("shows the exact manual status returned while opening a restored project", async () => {
     const user = userEvent.setup();
     api.applyRestore.mockResolvedValue(restoreReportWithRegistration("manual_open_required"));

--- a/desktop/src/features/receive/ReceivePage.tsx
+++ b/desktop/src/features/receive/ReceivePage.tsx
@@ -294,9 +294,10 @@ export default function ReceivePage({
           <div className="verification-list">
             {verificationLabels.map(([key, label]) => {
               const passed = report.verification[key];
-              return <span key={key} className={passed ? "verification-pass" : "verification-fail"}>{passed ? <CheckCircle2 aria-hidden="true" /> : <AlertTriangle aria-hidden="true" />}{t(label)}</span>;
+              return <span key={key} className={passed ? "verification-pass" : "verification-fail"}>{passed ? <CheckCircle2 aria-hidden="true" /> : <AlertTriangle aria-hidden="true" />}{t(key === "app_visible_ready" && !passed ? "对话可见性待确认" : label)}</span>;
             })}
           </div>
+          {!report.verification.app_visible_ready && <p className="manual-status" role="status"><AlertTriangle aria-hidden="true" />{t("文件和索引已导入。请重启 Codex，打开原对话并继续发送一条消息，确认可以使用。")}</p>}
           {manualRegistration && <p className="manual-status" role="status"><AlertTriangle aria-hidden="true" />{t("项目文件已导入，需要在 Codex 中手动打开")}</p>}
           {report.registrations.map((registration) => (
             <div className="registration-row" key={registration.project_id}><code>{registration.project_path}</code><button className="secondary-button" type="button" onClick={() => void handleOpenRestored(registration)}><FolderOpen aria-hidden="true" />{t("在 Codex 中打开")}</button>{registrationStatuses[registration.project_id] && <span role="status">{registrationStatuses[registration.project_id]}</span>}</div>

--- a/desktop/src/features/receive/ReceivePage.tsx
+++ b/desktop/src/features/receive/ReceivePage.tsx
@@ -299,9 +299,11 @@ export default function ReceivePage({
           </div>
           {!report.verification.app_visible_ready && <p className="manual-status" role="status"><AlertTriangle aria-hidden="true" />{t("文件和索引已导入。请重启 Codex，打开原对话并继续发送一条消息，确认可以使用。")}</p>}
           {manualRegistration && <p className="manual-status" role="status"><AlertTriangle aria-hidden="true" />{t("项目文件已导入，需要在 Codex 中手动打开")}</p>}
-          {report.registrations.map((registration) => (
-            <div className="registration-row" key={registration.project_id}><code>{registration.project_path}</code><button className="secondary-button" type="button" onClick={() => void handleOpenRestored(registration)}><FolderOpen aria-hidden="true" />{t("在 Codex 中打开")}</button>{registrationStatuses[registration.project_id] && <span role="status">{registrationStatuses[registration.project_id]}</span>}</div>
-          ))}
+          {report.registrations.map((registration) => {
+            const message = registrationStatuses[registration.project_id]
+              ?? (typeof registration.status === "object" ? registration.status.invocation_failed.message : null);
+            return <div className="registration-row" key={registration.project_id}><code>{registration.project_path}</code><button className="secondary-button" type="button" onClick={() => void handleOpenRestored(registration)}><FolderOpen aria-hidden="true" />{t("在 Codex 中打开")}</button>{message && <span role="status">{message}</span>}</div>;
+          })}
         </section>
       )}
     </div>

--- a/desktop/src/lib/i18n.tsx
+++ b/desktop/src/lib/i18n.tsx
@@ -156,6 +156,8 @@ const english: Record<string, string> = {
   "项目文件": "Project files",
   "Codex 项目登记": "Codex project registration",
   "Codex 可见状态": "Codex visibility",
+  "对话可见性待确认": "Conversation visibility not yet verified",
+  "文件和索引已导入。请重启 Codex，打开原对话并继续发送一条消息，确认可以使用。": "Files and indexes have been imported. Restart Codex, open the original conversation, and send another message to confirm it works.",
   "项目文件已导入，需要在 Codex 中手动打开": "Project files were imported and must be opened manually in Codex",
   "在 Codex 中打开": "Open in Codex",
   "检查": "Inspect",


### PR DESCRIPTION
## Summary

- Discover macOS Codex CLI inside both ChatGPT.app and Codex.app, including the current user's Applications directory.
- Prefer recognized applications running under the current user, supporting nonstandard installation locations without searching arbitrary bundles or executing shell strings.
- Include the attempted executable in invocation failures and display initial registration errors immediately on the import result page.
- Keep conversation visibility explicitly unverified: successful project registration alone does not prove original conversations can be opened and resumed.

## Reproduction

On a Mac with ChatGPT.app installed and Codex.app absent, 0.1.22 imports the selected data successfully but fails automatic project registration. Running the installed application's `Contents/Resources/codex app <project>` succeeds. The previous detector only inspected `/Applications/Codex.app`.

## Verification

- Regression tests for both application names, system/user locations, running-app priority, candidate deduplication, and unrelated-bundle exclusion failed before the fix.
- Initial-error UI regression failed before the fix.
- Local Rust suite: 239 passed, 3 intentionally ignored.
- UI suite: 43 passed; production frontend build and Clippy passed.
- Candidate CI passed Windows/macOS tests and both installers. Version 0.1.23 receives a fresh CI run.

## Acceptance boundary

Physical Mac retest passed on macOS 12.7.6 Intel with ChatGPT.app 26.727.51351: automatic registration without manual repair, project persistence after restart, original two-turn history, API continuation and Skill invocation. Direct manual UI typing and signing/notarization are not covered. The accepted candidate's product code is unchanged; version metadata is bumped to 0.1.23 for release. Command invocation failures do not automatically launch a different installed application. This single legacy-conversation sample does not establish all history-chain variants or all platform directions.
