### PR TITLE
Fix Windows native path separators (0.1.24)

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rehome-desktop",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rehome-desktop",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-process": "^2.3.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rehome-desktop",
   "private": true,
-  "version": "0.1.23",
+  "version": "0.1.24",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2886,7 +2886,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rehome-desktop"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rehome-desktop"
-version = "0.1.23"
+version = "0.1.24"
 description = "ReHome Desktop migration utility"
 authors = ["ReHome contributors"]
 edition = "2021"

--- a/desktop/src-tauri/src/core/stable_fs.rs
+++ b/desktop/src-tauri/src/core/stable_fs.rs
@@ -5,6 +5,79 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn pinned_mutations_preserve_literal_backslash_in_unix_names() {
+        let root = tempfile::tempdir().unwrap();
+        let pinned = PinnedParent::open(root.path()).unwrap();
+        pinned
+            .replace_bytes(OsStr::new(r"literal\name"), b"unchanged")
+            .unwrap();
+        assert_eq!(
+            fs::read(root.path().join(r"literal\name")).unwrap(),
+            b"unchanged"
+        );
+        assert!(!root.path().join("literal/name").exists());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_api_path_normalizes_only_native_separators() {
+        use std::path::Path;
+        for (input, expected) in [
+            (r"C:/用户/test folder", r"\\?\C:\用户\test folder"),
+            (r"C:\用户/test folder", r"\\?\C:\用户\test folder"),
+            (r"//server/share/folder", r"\\?\UNC\server\share\folder"),
+            (r"\\server\share/folder", r"\\?\UNC\server\share\folder"),
+            (r"\\?\C:\already\extended", r"\\?\C:\already\extended"),
+            (r"\\?\C:\literal/slash", r"\\?\C:\literal/slash"),
+            (
+                r"\\?\UNC\server\share\folder",
+                r"\\?\UNC\server\share\folder",
+            ),
+        ] {
+            let actual = super::windows_api_path(Path::new(input));
+            assert_eq!(actual.last(), Some(&0));
+            assert_eq!(
+                String::from_utf16(&actual[..actual.len() - 1]).unwrap(),
+                expected
+            );
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_pinned_mutations_support_forward_slash_parent() {
+        use std::{io::Read, path::PathBuf};
+        let root = tempfile::tempdir().unwrap();
+        let parent = root.path().join("中文 space").join("long".repeat(55));
+        fs::create_dir_all(&parent).unwrap();
+        let slash_parent = PathBuf::from(parent.to_str().unwrap().replace('\\', "/"));
+        let pinned = PinnedParent::open(&slash_parent).unwrap();
+        pinned
+            .replace_bytes(OsStr::new("target"), b"original")
+            .unwrap();
+        pinned
+            .replace_bytes(OsStr::new("target"), b"replacement")
+            .unwrap();
+        let mut bytes = Vec::new();
+        pinned
+            .open_file(OsStr::new("target"))
+            .unwrap()
+            .read_to_end(&mut bytes)
+            .unwrap();
+        assert_eq!(bytes, b"replacement");
+        pinned
+            .rename_child_if_absent(OsStr::new("target"), OsStr::new("renamed"))
+            .unwrap();
+        assert!(pinned.child_exists(OsStr::new("renamed")).unwrap());
+        assert!(pinned
+            .replace_bytes(OsStr::new("../escape"), b"unsafe")
+            .is_err());
+        pinned.remove_file(OsStr::new("renamed")).unwrap();
+        assert!(!parent.join("renamed").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn pinned_replace_never_writes_through_a_swapped_parent() {
         let root = tempfile::tempdir().unwrap();
         let parent = root.path().join("parent");
@@ -615,6 +688,13 @@ fn windows_api_path(path: &Path) -> Vec<u16> {
     if raw.starts_with(&[BACKSLASH, BACKSLASH, QUESTION, BACKSLASH]) {
         return raw.into_iter().chain(Some(0)).collect();
     }
+    // Ordinary Win32 paths accept both separators, but the verbatim prefix
+    // disables that conversion. Normalize only at this native API boundary;
+    // already-verbatim paths above retain their literal semantics.
+    let raw = raw
+        .into_iter()
+        .map(|unit| if unit == b'/' as u16 { BACKSLASH } else { unit })
+        .collect::<Vec<_>>();
     let mut extended = Vec::with_capacity(raw.len() + 9);
     if raw.starts_with(&[BACKSLASH, BACKSLASH]) {
         extended.extend(r"\\?\UNC\".encode_utf16());

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ReHome Desktop",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "identifier": "com.calebycj.rehome",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src-tauri/tests/restore_test.rs
+++ b/desktop/src-tauri/tests/restore_test.rs
@@ -35,6 +35,45 @@ use zip::{write::SimpleFileOptions, CompressionMethod, DateTime, ZipArchive, Zip
 
 static APP_DATA_ENV_LOCK: Mutex<()> = Mutex::new(());
 
+#[cfg(windows)]
+#[test]
+fn windows_forward_slash_codex_home_restores_and_rolls_back() -> Result<(), Box<dyn Error>> {
+    let harness = RestoreHarness::new(DatabaseSchema::Compatible)?;
+    let original = fs::read(harness.plan.target_codex_home.join("state_5.sqlite"))?;
+    let ordinary = harness
+        .plan
+        .target_codex_home
+        .to_str()
+        .unwrap()
+        .strip_prefix(r"\\?\")
+        .unwrap();
+    let target = TargetInventory {
+        codex_home: PathBuf::from(ordinary.replace('\\', "/")),
+        target_os: SourceOs::Windows,
+        target_arch: "x86_64".into(),
+        counts: ContentCounts::default(),
+        projects: vec![],
+        conversations: vec![],
+    };
+    let plan = build_restore_plan(
+        &inspect_package(&harness.plan.package_path)?,
+        &target,
+        &harness.plan.projects_root,
+    )?;
+    let report = apply_restore(plan, harness.options())?;
+    assert!(report.verification.files_valid);
+    assert!(report.verification.sessions_valid);
+    assert!(report.verification.sqlite_threads_valid);
+    assert!(report.verification.session_index_valid);
+    assert!(report.verification.path_mapping_valid);
+    assert!(rollback(report.transaction_id)?.success);
+    assert_eq!(
+        fs::read(target.codex_home.join("state_5.sqlite"))?,
+        original
+    );
+    Ok(())
+}
+
 #[test]
 #[ignore = "set REHOME_UI_FIXTURE_ROOT to a new directory for isolated desktop acceptance"]
 fn prepare_synthetic_desktop_acceptance_fixture() -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
## Summary
- Fix Windows imports when an ordinary custom CODEX_HOME uses forward or mixed separators. Normalize UTF-16 separator units before adding the Win32 extended-length prefix.
- Keep already-verbatim paths literal; do not change portable archives, conversation text, macOS paths, containment checks, directory pinning, or rollback.
- Bump desktop version to 0.1.24.

## Evidence
- Two focused regressions failed before the implementation and passed afterward.
- Added drive/UNC/mixed/Unicode/space/verbatim conversion coverage, long-path pinned filesystem operations, Windows restore plus byte-exact database rollback, and a Unix literal-backslash regression.
- Full local Rust suite, frontend 43 tests, Clippy, formatting, frontend/NSIS builds, updater and README checks passed.
- Locally built release app GUI imported the exact previously failing isolated real-source package with forward-slash CODEX_HOME; file, session, index, SQLite, path, exclusion, project and registration verification passed.
- This is not a claim of fresh physical Mac acceptance or in-app updater installation. UNC coverage is conversion testing, not an actual network share.
- Existing issues #44/#46 are not established as the same cause and are not closed by this PR.
